### PR TITLE
feat(plugin-stable): switch to stable version to avoid disruptions

### DIFF
--- a/manifests/openshift-conformance-validated.yaml
+++ b/manifests/openshift-conformance-validated.yaml
@@ -3,7 +3,7 @@ podSpec:
   serviceAccountName: sonobuoy-serviceaccount
   containers:
     - name: report-progress
-      image: quay.io/mrbraga/openshift-tests-provider-cert:devel
+      image: quay.io/ocp-cert/openshift-tests-provider-cert:stable
       imagePullPolicy: Always
       priorityClassName: system-node-critical
       command: ["./report-progress.sh"]
@@ -34,7 +34,7 @@ sonobuoy-config:
   skipCleanup: true
 spec:
   name: plugin
-  image: quay.io/mrbraga/openshift-tests-provider-cert:devel
+  image: quay.io/ocp-cert/openshift-tests-provider-cert:stable
   imagePullPolicy: Always
   priorityClassName: system-node-critical
   volumeMounts:

--- a/manifests/openshift-kube-conformance.yaml
+++ b/manifests/openshift-kube-conformance.yaml
@@ -3,7 +3,7 @@ podSpec:
   serviceAccountName: sonobuoy-serviceaccount
   containers:
     - name: report-progress
-      image: quay.io/mrbraga/openshift-tests-provider-cert:devel
+      image: quay.io/ocp-cert/openshift-tests-provider-cert:stable
       imagePullPolicy: Always
       priorityClassName: system-node-critical
       command: ["./report-progress.sh"]
@@ -34,7 +34,7 @@ sonobuoy-config:
   skipCleanup: true
 spec:
   name: plugin
-  image: quay.io/mrbraga/openshift-tests-provider-cert:devel
+  image: quay.io/ocp-cert/openshift-tests-provider-cert:stable
   imagePullPolicy: Always
   priorityClassName: system-node-critical
   volumeMounts:

--- a/pkg/assets/bindata.go
+++ b/pkg/assets/bindata.go
@@ -59,7 +59,7 @@ var _manifestsOpenshiftConformanceValidatedYaml = []byte(`podSpec:
   serviceAccountName: sonobuoy-serviceaccount
   containers:
     - name: report-progress
-      image: quay.io/mrbraga/openshift-tests-provider-cert:devel
+      image: quay.io/ocp-cert/openshift-tests-provider-cert:stable
       imagePullPolicy: Always
       priorityClassName: system-node-critical
       command: ["./report-progress.sh"]
@@ -90,7 +90,7 @@ sonobuoy-config:
   skipCleanup: true
 spec:
   name: plugin
-  image: quay.io/mrbraga/openshift-tests-provider-cert:devel
+  image: quay.io/ocp-cert/openshift-tests-provider-cert:stable
   imagePullPolicy: Always
   priorityClassName: system-node-critical
   volumeMounts:
@@ -133,7 +133,7 @@ var _manifestsOpenshiftKubeConformanceYaml = []byte(`podSpec:
   serviceAccountName: sonobuoy-serviceaccount
   containers:
     - name: report-progress
-      image: quay.io/mrbraga/openshift-tests-provider-cert:devel
+      image: quay.io/ocp-cert/openshift-tests-provider-cert:stable
       imagePullPolicy: Always
       priorityClassName: system-node-critical
       command: ["./report-progress.sh"]
@@ -164,7 +164,7 @@ sonobuoy-config:
   skipCleanup: true
 spec:
   name: plugin
-  image: quay.io/mrbraga/openshift-tests-provider-cert:devel
+  image: quay.io/ocp-cert/openshift-tests-provider-cert:stable
   imagePullPolicy: Always
   priorityClassName: system-node-critical
   volumeMounts:

--- a/pkg/run/run.go
+++ b/pkg/run/run.go
@@ -105,7 +105,7 @@ func NewCmdRun() *cobra.Command {
 
 	cmd.Flags().BoolVar(&o.dedicated, "dedicated", false, "Setup plugins to run in dedicated test environment.")
 	cmd.Flags().StringArrayVar(o.plugins, "plugin", nil, "Override default conformance plugins to use. Can be used multiple times (defaults to latest plugins in https://github.com/openshift/provider-certification-tool)")
-	cmd.Flags().StringVar(&o.sonobuoyImage, "sonobuoy-image", fmt.Sprintf("quay.io/mrbraga/sonobuoy:%s", buildinfo.Version), "Image override for the Sonobuoy worker and aggregator")
+	cmd.Flags().StringVar(&o.sonobuoyImage, "sonobuoy-image", fmt.Sprintf("quay.io/ocp-cert/sonobuoy:%s", buildinfo.Version), "Image override for the Sonobuoy worker and aggregator")
 	cmd.Flags().IntVar(&o.timeout, "timeout", runTimeoutSeconds, "Execution timeout in seconds")
 	cmd.Flags().BoolVarP(&o.watch, "watch", "w", false, "Keep watch status after running")
 


### PR DESCRIPTION
We are using `stable` version of the plugin image to avoid disruptions when many engineers are testing different components on the certificate system.