### PR TITLE
chore: fixing package naming due to repo move

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ export CGO_ENABLED=0
 VERSION=$(shell git rev-parse --short HEAD)
 RELEASE_TAG ?= 0.0.0
 
-GO_BUILD_FLAGS := -ldflags '-X github.com/openshift/provider-certification-tool/version.commit=$(VERSION) -X github.com/openshift/provider-certification-tool/version.version=$(RELEASE_TAG)'
+GO_BUILD_FLAGS := -ldflags '-X github.com/redhat-openshift-ecosystem/provider-certification-tool/pkg/version.commit=$(VERSION) -X github.com/redhat-openshift-ecosystem/provider-certification-tool/pkg/version.version=$(RELEASE_TAG)'
 
 # Unset GOFLAG for CI and ensure we've got nothing accidently set
 unexport GOFLAGS

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -10,12 +10,12 @@ import (
 	"github.com/spf13/viper"
 	"github.com/vmware-tanzu/sonobuoy/cmd/sonobuoy/app"
 
-	"github.com/openshift/provider-certification-tool/pkg/assets"
-	"github.com/openshift/provider-certification-tool/pkg/destroy"
-	"github.com/openshift/provider-certification-tool/pkg/retrieve"
-	"github.com/openshift/provider-certification-tool/pkg/run"
-	"github.com/openshift/provider-certification-tool/pkg/status"
-	"github.com/openshift/provider-certification-tool/pkg/version"
+	"github.com/redhat-openshift-ecosystem/provider-certification-tool/pkg/assets"
+	"github.com/redhat-openshift-ecosystem/provider-certification-tool/pkg/destroy"
+	"github.com/redhat-openshift-ecosystem/provider-certification-tool/pkg/retrieve"
+	"github.com/redhat-openshift-ecosystem/provider-certification-tool/pkg/run"
+	"github.com/redhat-openshift-ecosystem/provider-certification-tool/pkg/status"
+	"github.com/redhat-openshift-ecosystem/provider-certification-tool/pkg/version"
 )
 
 // rootCmd represents the base command when called without any subcommands
@@ -36,7 +36,7 @@ var rootCmd = &cobra.Command{
 
 		// Additional log options
 		log.SetFormatter(&log.TextFormatter{
-		    FullTimestamp: true,
+			FullTimestamp: true,
 		})
 	},
 }

--- a/go.mod
+++ b/go.mod
@@ -1,9 +1,9 @@
-module github.com/openshift/provider-certification-tool
+module github.com/redhat-openshift-ecosystem/provider-certification-tool
 
 go 1.17
 
 require (
-	github.com/openshift/api v0.0.0-20210910062324-a41d3573a3ba // indirect
+	github.com/openshift/api v0.0.0-20210910062324-a41d3573a3ba
 	github.com/openshift/client-go v0.0.0-20210521082421-73d9475a9142
 	github.com/pkg/errors v0.9.1
 	github.com/sirupsen/logrus v1.4.2

--- a/hack/go-imports.sh
+++ b/hack/go-imports.sh
@@ -9,8 +9,8 @@ if [ "$IS_CONTAINER" != "" ]; then
 else
   podman run --rm \
     --env IS_CONTAINER=TRUE \
-    --volume "${PWD}:/go/src/github.com/openshift/provider-certification-tool:z" \
-    --workdir /go/src/github.com/openshift/provider-certification-tool \
+    --volume "${PWD}:/go/src/github.com/redhat-openshift-ecosystem/provider-certification-tool:z" \
+    --workdir /go/src/github.com/redhat-openshift-ecosystem/provider-certification-tool \
     docker.io/golang:1.17 \
     ./hack/go-imports.sh "${@}"
 fi

--- a/hack/go-staticcheck.sh
+++ b/hack/go-staticcheck.sh
@@ -7,8 +7,8 @@ if [ "$IS_CONTAINER" != "" ]; then
 else
   podman run --rm \
     --env IS_CONTAINER=TRUE \
-    --volume "${PWD}:/go/src/github.com/openshift/provider-certification-tool:z" \
-    --workdir /go/src/github.com/openshift/provider-certification-tool \
+    --volume "${PWD}:/go/src/github.com/redhat-openshift-ecosystem/provider-certification-tool:z" \
+    --workdir /go/src/github.com/redhat-openshift-ecosystem/provider-certification-tool \
     docker.io/golang:1.17 \
     ./hack/go-staticcheck.sh "${@}"
 fi

--- a/main.go
+++ b/main.go
@@ -1,6 +1,6 @@
 package main
 
-import "github.com/openshift/provider-certification-tool/cmd"
+import "github.com/redhat-openshift-ecosystem/provider-certification-tool/cmd"
 
 func main() {
 	cmd.Execute()

--- a/manifests/openshift-conformance-validated.yaml
+++ b/manifests/openshift-conformance-validated.yaml
@@ -30,7 +30,7 @@ sonobuoy-config:
   plugin-name: openshift-conformance-validated
   result-format: junit
   description: The end-to-end tests maintained by OpenShift to certify the Provider running the OpenShift Container Platform.
-  source-url: https://github.com/openshift/provider-certification-tool/blob/mvp/tools/plugins/openshift-conformance-validated.yaml
+  source-url: https://github.com/redhat-openshift-ecosystem/provider-certification-tool/blob/mvp/tools/plugins/openshift-conformance-validated.yaml
   skipCleanup: true
 spec:
   name: plugin

--- a/manifests/openshift-kube-conformance.yaml
+++ b/manifests/openshift-kube-conformance.yaml
@@ -30,7 +30,7 @@ sonobuoy-config:
   plugin-name: openshift-kube-conformance
   result-format: junit
   description: The end-to-end tests maintained by Kubernetes to certify the platform.
-  source-url: https://github.com/openshift/provider-certification-tool/blob/mvp/tools/plugins/openshift-kube-conformance.yaml
+  source-url: https://github.com/redhat-openshift-ecosystem/provider-certification-tool/blob/mvp/tools/plugins/openshift-kube-conformance.yaml
   skipCleanup: true
 spec:
   name: plugin

--- a/pkg/assets/bindata.go
+++ b/pkg/assets/bindata.go
@@ -86,7 +86,7 @@ sonobuoy-config:
   plugin-name: openshift-conformance-validated
   result-format: junit
   description: The end-to-end tests maintained by OpenShift to certify the Provider running the OpenShift Container Platform.
-  source-url: https://github.com/openshift/provider-certification-tool/blob/mvp/tools/plugins/openshift-conformance-validated.yaml
+  source-url: https://github.com/redhat-openshift-ecosystem/provider-certification-tool/blob/mvp/tools/plugins/openshift-conformance-validated.yaml
   skipCleanup: true
 spec:
   name: plugin
@@ -160,7 +160,7 @@ sonobuoy-config:
   plugin-name: openshift-kube-conformance
   result-format: junit
   description: The end-to-end tests maintained by Kubernetes to certify the platform.
-  source-url: https://github.com/openshift/provider-certification-tool/blob/mvp/tools/plugins/openshift-kube-conformance.yaml
+  source-url: https://github.com/redhat-openshift-ecosystem/provider-certification-tool/blob/mvp/tools/plugins/openshift-kube-conformance.yaml
   skipCleanup: true
 spec:
   name: plugin

--- a/pkg/destroy/destroy.go
+++ b/pkg/destroy/destroy.go
@@ -11,8 +11,8 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 
-	"github.com/openshift/provider-certification-tool/pkg"
-	"github.com/openshift/provider-certification-tool/pkg/client"
+	"github.com/redhat-openshift-ecosystem/provider-certification-tool/pkg"
+	"github.com/redhat-openshift-ecosystem/provider-certification-tool/pkg/client"
 )
 
 const (

--- a/pkg/retrieve/retrieve.go
+++ b/pkg/retrieve/retrieve.go
@@ -12,9 +12,9 @@ import (
 	config2 "github.com/vmware-tanzu/sonobuoy/pkg/config"
 	"golang.org/x/sync/errgroup"
 
-	"github.com/openshift/provider-certification-tool/pkg"
-	"github.com/openshift/provider-certification-tool/pkg/client"
-	"github.com/openshift/provider-certification-tool/pkg/status"
+	"github.com/redhat-openshift-ecosystem/provider-certification-tool/pkg"
+	"github.com/redhat-openshift-ecosystem/provider-certification-tool/pkg/client"
+	"github.com/redhat-openshift-ecosystem/provider-certification-tool/pkg/status"
 )
 
 func NewCmdRetrieve() *cobra.Command {

--- a/pkg/run/run.go
+++ b/pkg/run/run.go
@@ -23,11 +23,11 @@ import (
 	"k8s.io/apimachinery/pkg/util/json"
 	"k8s.io/client-go/kubernetes"
 
-	"github.com/openshift/provider-certification-tool/pkg"
-	"github.com/openshift/provider-certification-tool/pkg/assets"
-	"github.com/openshift/provider-certification-tool/pkg/client"
-	"github.com/openshift/provider-certification-tool/pkg/status"
-	"github.com/openshift/provider-certification-tool/pkg/wait"
+	"github.com/redhat-openshift-ecosystem/provider-certification-tool/pkg"
+	"github.com/redhat-openshift-ecosystem/provider-certification-tool/pkg/assets"
+	"github.com/redhat-openshift-ecosystem/provider-certification-tool/pkg/client"
+	"github.com/redhat-openshift-ecosystem/provider-certification-tool/pkg/status"
+	"github.com/redhat-openshift-ecosystem/provider-certification-tool/pkg/wait"
 )
 
 type RunOptions struct {
@@ -104,7 +104,7 @@ func NewCmdRun() *cobra.Command {
 	}
 
 	cmd.Flags().BoolVar(&o.dedicated, "dedicated", false, "Setup plugins to run in dedicated test environment.")
-	cmd.Flags().StringArrayVar(o.plugins, "plugin", nil, "Override default conformance plugins to use. Can be used multiple times (defaults to latest plugins in https://github.com/openshift/provider-certification-tool)")
+	cmd.Flags().StringArrayVar(o.plugins, "plugin", nil, "Override default conformance plugins to use. Can be used multiple times. (default plugins can be reviewed with assets subcommand)")
 	cmd.Flags().StringVar(&o.sonobuoyImage, "sonobuoy-image", fmt.Sprintf("quay.io/ocp-cert/sonobuoy:%s", buildinfo.Version), "Image override for the Sonobuoy worker and aggregator")
 	cmd.Flags().IntVar(&o.timeout, "timeout", runTimeoutSeconds, "Execution timeout in seconds")
 	cmd.Flags().BoolVarP(&o.watch, "watch", "w", false, "Keep watch status after running")

--- a/pkg/status/status.go
+++ b/pkg/status/status.go
@@ -14,9 +14,9 @@ import (
 	wait2 "k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/kubernetes"
 
-	"github.com/openshift/provider-certification-tool/pkg"
-	"github.com/openshift/provider-certification-tool/pkg/client"
-	"github.com/openshift/provider-certification-tool/pkg/wait"
+	"github.com/redhat-openshift-ecosystem/provider-certification-tool/pkg"
+	"github.com/redhat-openshift-ecosystem/provider-certification-tool/pkg/client"
+	"github.com/redhat-openshift-ecosystem/provider-certification-tool/pkg/wait"
 )
 
 const (

--- a/pkg/wait/util.go
+++ b/pkg/wait/util.go
@@ -14,7 +14,7 @@ import (
 	"k8s.io/client-go/tools/cache"
 	watchtools "k8s.io/client-go/tools/watch"
 
-	"github.com/openshift/provider-certification-tool/pkg"
+	"github.com/redhat-openshift-ecosystem/provider-certification-tool/pkg"
 )
 
 // WaitForRequiredResources will wait for the sonobuoy pod in the sonobuoy namespace to go into


### PR DESCRIPTION
Since we've moved from github.com/openshift to _here_ we need to fix up some code. This includes those changes. Nothing functional has been modified, only strings. 

SPLAT-625