### PR TITLE
chore(plugin-manifest): add shared volume

### DIFF
--- a/manifests/openshift-conformance-validated.yaml
+++ b/manifests/openshift-conformance-validated.yaml
@@ -1,6 +1,9 @@
 podSpec:
   restartPolicy: Never
   serviceAccountName: sonobuoy-serviceaccount
+  volumes:
+    - name: shared
+      emptyDir: {}
   containers:
     - name: report-progress
       image: quay.io/ocp-cert/openshift-tests-provider-cert:stable
@@ -10,6 +13,8 @@ podSpec:
       volumeMounts:
       - mountPath: /tmp/sonobuoy/results
         name: results
+      - mountPath: /tmp/shared
+        name: shared
       env:
         - name: CERT_LEVEL
           value: "1"
@@ -40,6 +45,8 @@ spec:
   volumeMounts:
   - mountPath: /tmp/sonobuoy/results
     name: results
+  - mountPath: /tmp/shared
+    name: shared
   env:
     - name: CERT_LEVEL
       value: "1"

--- a/manifests/openshift-kube-conformance.yaml
+++ b/manifests/openshift-kube-conformance.yaml
@@ -1,6 +1,9 @@
 podSpec:
   restartPolicy: Never
   serviceAccountName: sonobuoy-serviceaccount
+  volumes:
+    - name: shared
+      emptyDir: {}
   containers:
     - name: report-progress
       image: quay.io/ocp-cert/openshift-tests-provider-cert:stable
@@ -10,6 +13,8 @@ podSpec:
       volumeMounts:
       - mountPath: /tmp/sonobuoy/results
         name: results
+      - mountPath: /tmp/shared
+        name: shared
       env:
         - name: CERT_LEVEL
           value: "0"
@@ -40,6 +45,8 @@ spec:
   volumeMounts:
   - mountPath: /tmp/sonobuoy/results
     name: results
+  - mountPath: /tmp/shared
+    name: shared
   env:
     - name: CERT_LEVEL
       value: "0"

--- a/pkg/assets/bindata.go
+++ b/pkg/assets/bindata.go
@@ -57,6 +57,9 @@ func (fi bindataFileInfo) Sys() interface{} {
 var _manifestsOpenshiftConformanceValidatedYaml = []byte(`podSpec:
   restartPolicy: Never
   serviceAccountName: sonobuoy-serviceaccount
+  volumes:
+    - name: shared
+      emptyDir: {}
   containers:
     - name: report-progress
       image: quay.io/ocp-cert/openshift-tests-provider-cert:stable
@@ -66,6 +69,8 @@ var _manifestsOpenshiftConformanceValidatedYaml = []byte(`podSpec:
       volumeMounts:
       - mountPath: /tmp/sonobuoy/results
         name: results
+      - mountPath: /tmp/shared
+        name: shared
       env:
         - name: CERT_LEVEL
           value: "1"
@@ -96,6 +101,8 @@ spec:
   volumeMounts:
   - mountPath: /tmp/sonobuoy/results
     name: results
+  - mountPath: /tmp/shared
+    name: shared
   env:
     - name: CERT_LEVEL
       value: "1"
@@ -131,6 +138,9 @@ func manifestsOpenshiftConformanceValidatedYaml() (*asset, error) {
 var _manifestsOpenshiftKubeConformanceYaml = []byte(`podSpec:
   restartPolicy: Never
   serviceAccountName: sonobuoy-serviceaccount
+  volumes:
+    - name: shared
+      emptyDir: {}
   containers:
     - name: report-progress
       image: quay.io/ocp-cert/openshift-tests-provider-cert:stable
@@ -140,6 +150,8 @@ var _manifestsOpenshiftKubeConformanceYaml = []byte(`podSpec:
       volumeMounts:
       - mountPath: /tmp/sonobuoy/results
         name: results
+      - mountPath: /tmp/shared
+        name: shared
       env:
         - name: CERT_LEVEL
           value: "0"
@@ -170,6 +182,8 @@ spec:
   volumeMounts:
   - mountPath: /tmp/sonobuoy/results
     name: results
+  - mountPath: /tmp/shared
+    name: shared
   env:
     - name: CERT_LEVEL
       value: "0"


### PR DESCRIPTION
Add shared volume to avoid mixing internal files (kubeconfig, aggregator status file, openshift-tests utility, openshift-tests stat file, etc) to non-related with sonobuoy results, but being used in the SONOBUOY_RESULT_DIR

Ref https://github.com/redhat-openshift-ecosystem/provider-certification-plugins/pull/13