### PR TITLE
chore(promote): renaming mvp -> main

### DIFF
--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -4,7 +4,6 @@ on:
   pull_request:
     branches:
       - main
-      - mvp
       - release-*
   push:
     tags:

--- a/manifests/openshift-conformance-validated.yaml
+++ b/manifests/openshift-conformance-validated.yaml
@@ -35,7 +35,7 @@ sonobuoy-config:
   plugin-name: openshift-conformance-validated
   result-format: junit
   description: The end-to-end tests maintained by OpenShift to certify the Provider running the OpenShift Container Platform.
-  source-url: https://github.com/redhat-openshift-ecosystem/provider-certification-tool/blob/mvp/manifests/openshift-conformance-validated.yaml
+  source-url: https://github.com/redhat-openshift-ecosystem/provider-certification-tool/blob/main/manifests/openshift-conformance-validated.yaml
   skipCleanup: true
 spec:
   name: plugin

--- a/manifests/openshift-kube-conformance.yaml
+++ b/manifests/openshift-kube-conformance.yaml
@@ -35,7 +35,7 @@ sonobuoy-config:
   plugin-name: openshift-kube-conformance
   result-format: junit
   description: The end-to-end tests maintained by Kubernetes to certify the platform.
-  source-url: https://github.com/redhat-openshift-ecosystem/provider-certification-tool/blob/mvp/manifests/openshift-kube-conformance.yaml
+  source-url: https://github.com/redhat-openshift-ecosystem/provider-certification-tool/blob/main/manifests/openshift-kube-conformance.yaml
   skipCleanup: true
 spec:
   name: plugin

--- a/pkg/assets/bindata.go
+++ b/pkg/assets/bindata.go
@@ -91,7 +91,7 @@ sonobuoy-config:
   plugin-name: openshift-conformance-validated
   result-format: junit
   description: The end-to-end tests maintained by OpenShift to certify the Provider running the OpenShift Container Platform.
-  source-url: https://github.com/redhat-openshift-ecosystem/provider-certification-tool/blob/mvp/manifests/openshift-conformance-validated.yaml
+  source-url: https://github.com/redhat-openshift-ecosystem/provider-certification-tool/blob/main/manifests/openshift-conformance-validated.yaml
   skipCleanup: true
 spec:
   name: plugin
@@ -172,7 +172,7 @@ sonobuoy-config:
   plugin-name: openshift-kube-conformance
   result-format: junit
   description: The end-to-end tests maintained by Kubernetes to certify the platform.
-  source-url: https://github.com/redhat-openshift-ecosystem/provider-certification-tool/blob/mvp/manifests/openshift-kube-conformance.yaml
+  source-url: https://github.com/redhat-openshift-ecosystem/provider-certification-tool/blob/main/manifests/openshift-kube-conformance.yaml
   skipCleanup: true
 spec:
   name: plugin


### PR DESCRIPTION
This PR will track moving code from the mvp to main branch. A few notes on the changes...

- Updating `SourceURL` should not make any functional changes to the manifests. ([source](https://github.com/vmware-tanzu/sonobuoy/blob/main/pkg/plugin/manifest/manifest.go#L49-L51))