### PR TITLE
chore(version): remove leading v from version output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-openshift-provider-cert
+openshift-provider-cert-*
 kubeconfig
 .idea/
 

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -28,7 +28,7 @@ type VersionContext struct {
 }
 
 func (vc *VersionContext) String() string {
-	return fmt.Sprintf("OpenShift Provider Certification Tool: v%s+%s", vc.Version, vc.Commit)
+	return fmt.Sprintf("OpenShift Provider Certification Tool: %s+%s", vc.Version, vc.Commit)
 }
 func NewCmdVersion() *cobra.Command {
 	return &cobra.Command{


### PR DESCRIPTION
The leading `v` will be included in tag name already. 