### PR TITLE
fix/doc: Compute pool should be always 16 GiB

### DIFF
--- a/docs/user.md
+++ b/docs/user.md
@@ -72,7 +72,7 @@ The dedicated node environment cluster size can be adjusted to match the table b
 | ------------- | ----- | --- | -------- | ------------ |
 | Bootstrap     | 1     | 4   | 16       | 100          |
 | Control Plane | 3     | 4   | 16       | 100          |
-| Compute       | 3     | 4   | 8        | 100          |
+| Compute       | 3     | 4   | 16       | 100          |
 | Dedicated Test| 1     | 4   | 8        | 100          |
 
 #### Environment Setup <a name="dedicated-env-setup"></a>


### PR DESCRIPTION
Keeping the `dedicated` RAM requirement for compute pool in sync with the regular environment to run certification tests.
/assign @bostrt 