### PR TITLE
SPLAT-858 Push CI certification results to quay

### DIFF
--- a/.github/workflows/push-image.yaml
+++ b/.github/workflows/push-image.yaml
@@ -1,0 +1,56 @@
+name: "Push CI Results Image"
+on:
+  workflow_dispatch:
+    inputs:
+      results_url:
+        description: URL to certification results in Prow CI artifact storage
+        required: true
+      cluster_version:
+        description: OpenShift cluster version
+        required: true
+      platformType:
+        description: Name of the platform where certification results were run  (e.g. AWS, vSphere)
+        required: true
+      descriptor:
+        description: Descriptor to append to container image name (e.g. disconnected)
+        required: false
+
+jobs:
+  push:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Build and push image
+      env:
+        QUAY_USER: ${{ secrets.QUAY_USER }}
+        QUAY_PASS: ${{ secrets.QUAY_PASS }}
+        RESULTS_URL: ${{ github.event.inputs.results_url }}
+        CLUSTER_VERSION: ${{ github.event.inputs.cluster_version }}
+        DESCRIPTOR: ${{ github.event.inputs.descriptor }}
+        PLATFORM_TYPE: ${{ github.event.inputs.platformType }}
+      run: |
+        DATE=$(date +%Y%m%d)
+        
+        # Login
+        podman login -u="${QUAY_USER}" -p="${QUAY_PASS}" quay.io
+        
+        # Create new empty container image and 
+        CONTAINER=$(buildah from scratch)
+
+        # Fetch certification archive and store in image
+        # rename to .tar.gz (.gz extension is stripped by Prow) 
+        wget -O results.tar.gz "${RESULTS_URL}"
+        buildah copy $CONTAINER *.tar.gz results.tar.gz
+        
+        IMAGE_NAME="quay.io/ocp-cert/baseline-results:${CLUSTER_VERSION}-${DATE}"
+        
+        # Insert descriptor if available
+        if [ ! -z "$DESCRIPTOR" ]; then
+          IMAGE_NAME="quay.io/ocp-cert/baseline-results:${CLUSTER_VERSION}-${DESCRIPTOR}-${DATE}"
+        fi
+        
+        # Add platformType label
+        buildah config --label ocpcert.platform="${PLATFORM_TYPE}" --created-by=redhat-openshift-ecosystem/provider-certification-tool/actions/workflows/push-image.yaml $CONTAINER 
+        
+        # Commit and push
+        buildah commit $CONTAINER "$IMAGE_NAME"
+        podman push "$IMAGE_NAME"

--- a/.github/workflows/push-image.yaml
+++ b/.github/workflows/push-image.yaml
@@ -29,7 +29,7 @@ jobs:
         RESULTS_URL: ${{ github.event.inputs.results_url }}
       run: |
         gsutil -m cp -r "${RESULTS_URL}" .
-        if [ $(ls certification-results/ | wc -l) != 1]; then
+        if [ $(ls certification-results/ | wc -l) != 1 ]; then
           echo 'Expecting single certification result archive' >&2
           ls certification-results/ >&2
           exit 1

--- a/.github/workflows/push-image.yaml
+++ b/.github/workflows/push-image.yaml
@@ -3,7 +3,7 @@ on:
   workflow_dispatch:
     inputs:
       results_url:
-        description: URL to certification results in Prow CI artifact storage
+        description: Google Cloud Storage URI (gs://) to certification results in Prow CI artifact storage
         required: true
       cluster_version:
         description: OpenShift cluster version
@@ -19,11 +19,25 @@ jobs:
   push:
     runs-on: ubuntu-latest
     steps:
+    - uses: actions/setup-python@v4
+      with:
+        python-version: '3.9'
+    - name: Install gsutil
+      run: pip install gsutil
+    - name: Download certification results
+      env:
+        RESULTS_URL: ${{ github.event.inputs.results_url }}
+      run: |
+        gsutil -m cp -r "${RESULTS_URL}" .
+        if [ $(ls certification-results/ | wc -l) != 1]; then
+          echo 'Expecting single certification result archive' >&2
+          ls certification-results/ >&2
+          exit 1
+        fi
     - name: Build and push image
       env:
         QUAY_USER: ${{ secrets.QUAY_USER }}
         QUAY_PASS: ${{ secrets.QUAY_PASS }}
-        RESULTS_URL: ${{ github.event.inputs.results_url }}
         CLUSTER_VERSION: ${{ github.event.inputs.cluster_version }}
         DESCRIPTOR: ${{ github.event.inputs.descriptor }}
         PLATFORM_TYPE: ${{ github.event.inputs.platformType }}
@@ -36,10 +50,9 @@ jobs:
         # Create new empty container image and 
         CONTAINER=$(buildah from scratch)
 
-        # Fetch certification archive and store in image
+        # Store certification results in image
         # rename to .tar.gz (.gz extension is stripped by Prow) 
-        wget -O results.tar.gz "${RESULTS_URL}"
-        buildah copy $CONTAINER *.tar.gz results.tar.gz
+        buildah copy $CONTAINER certification-results/*.tar results.tar.gz
         
         IMAGE_NAME="quay.io/ocp-cert/baseline-results:${CLUSTER_VERSION}-${DATE}"
         


### PR DESCRIPTION
GitHub Action that builds a container image containing only one file: `results.tar.gz`. The image is pushed to quay.io/ocp-cert/baseline-results as a new tag. This new GitHub Action will be triggered from a new OpenShift CI step in [this existing workflow](https://steps.ci.openshift.org/workflow/provider-certification-tool-vsphere-upi-platform-none) after a successful certification run. Triggering the GitHub Action can be done via GitHub API (a curl request).  


An example image (built with this GitHub Action) is available here to review in version `0.0.0`: https://quay.io/repository/ocp-cert/baseline-results?tab=tags

You can extract the results archive using:
```
oc image extract --file results.tar.gz quay.io/ocp-cert/baseline-results:0.0.0-20221101
```
Lastly, here's an example curl command that will be added to an OpenShift CI step (the Bearer token will need to be replaced and the `-d` value updated):
```
curl -X POST \
-H "Accept: Accept: application/vnd.github+json" \
-H "Authorization: Bearer XXXXXXXXXXXXXX" \
https://api.github.com/repos/redhat-openshift-ecosystem/provider-certification-tool/actions/workflows/push-image.yaml/dispatches \
-d '{"ref":"push-results","inputs":{"results_url":"https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/origin-ci-test/logs/periodic-ci-redhat-openshift-ecosystem-provider-certification-tool-main-provider-certification-tool-vsphere-upi-platform-none/1586870842078269440/artifacts/provider-certification-tool-vsphere-upi-platform-none/provider-certification-tool-run/artifacts/certification-results/202210310036_sonobuoy_f9888752-848c-4305-b181-0072b1023660.tar","cluster_version":"0.0.0","platformType":"vsphere"}}'
```
