### PR TITLE
SPLAT-850: Use dedicated mode by default

### DIFF
--- a/pkg/run/run.go
+++ b/pkg/run/run.go
@@ -113,7 +113,7 @@ func NewCmdRun() *cobra.Command {
 		},
 	}
 
-	cmd.Flags().BoolVar(&o.dedicated, "dedicated", false, "Setup plugins to run in dedicated test environment.")
+	cmd.Flags().BoolVar(&o.dedicated, "dedicated", true, "Setup plugins to run in dedicated test environment.")
 	cmd.Flags().StringArrayVar(o.plugins, "plugin", nil, "Override default conformance plugins to use. Can be used multiple times. (default plugins can be reviewed with assets subcommand)")
 	cmd.Flags().StringVar(&o.sonobuoyImage, "sonobuoy-image", fmt.Sprintf("quay.io/ocp-cert/sonobuoy:%s", buildinfo.Version), "Image override for the Sonobuoy worker and aggregator")
 	cmd.Flags().IntVar(&o.timeout, "timeout", runTimeoutSeconds, "Execution timeout in seconds")

--- a/pkg/run/run.go
+++ b/pkg/run/run.go
@@ -119,6 +119,9 @@ func NewCmdRun() *cobra.Command {
 	cmd.Flags().IntVar(&o.timeout, "timeout", runTimeoutSeconds, "Execution timeout in seconds")
 	cmd.Flags().BoolVarP(&o.watch, "watch", "w", false, "Keep watch status after running")
 
+	// Hide dedicated flag since this is for development only
+	cmd.Flags().MarkHidden("dedicated")
+
 	return cmd
 }
 


### PR DESCRIPTION
Change `--dedicated` to default true. 

Wait for https://github.com/redhat-openshift-ecosystem/provider-certification-tool/pull/23 to merge and then address documentation. 