### PR TITLE
chore/printer: update space to allow new plugin names

### DIFF
--- a/pkg/status/printer.go
+++ b/pkg/status/printer.go
@@ -25,8 +25,8 @@ type PrintablePluginStatus struct {
 }
 
 var runningStatusTemplate = `{{.CurrentTime}}> Global Status: {{.GlobalStatus}}
-{{printf "%-32s | %-10s | %-10s | %-25s | %-50s" "JOB_NAME" "STATUS" "RESULTS" "PROGRESS" "MESSAGE"}}{{range $index, $pl := .PluginStatuses}}
-{{printf "%-32s | %-10s | %-10s | %-25s | %-50s" $pl.Name $pl.Status $pl.Result $pl.Progress $pl.Message}}{{end}}
+{{printf "%-34s | %-10s | %-10s | %-25s | %-50s" "JOB_NAME" "STATUS" "RESULTS" "PROGRESS" "MESSAGE"}}{{range $index, $pl := .PluginStatuses}}
+{{printf "%-34s | %-10s | %-10s | %-25s | %-50s" $pl.Name $pl.Status $pl.Result $pl.Progress $pl.Message}}{{end}}
 `
 
 func PrintRunningStatus(s *aggregation.Status) error {


### PR DESCRIPTION
As the number of plugins will grow (upgrade, artifacts collector), this change will allow more space on the status table to fit new names:

~~~
Wed, 09 Nov 2022 13:29:17 -03> Global Status: running
JOB_NAME                           | STATUS     | RESULTS    | PROGRESS                  | MESSAGE
01-openshift-cluster-upgrade       | running    |            | 0/0 (0 failures)          | status=Working towards 4.11.12: 640 of 803 done (79% complete), waiting on service-ca
10-openshift-kube-conformance      | running    |            | 0/352 (0 failures)        | status=waiting-for=01-openshift-cluster-upgrade=(0/0/0)=[99/100]
20-openshift-conformance-validated | running    |            | 0/3487 (0 failures)       | status=blocked-by=10-openshift-kube-conformance=(0/-352/0)=[0/100]
99-openshift-artifacts-collector   | running    |            | 0/0 (0 failures)          | status=blocked-by=20-openshift-conformance-validated=(0/-3487/0)=[0/100]
~~~