### PR TITLE
OPCT-5: support upgrade execution mode

### DIFF
--- a/docs/user.md
+++ b/docs/user.md
@@ -110,7 +110,7 @@ cat << EOF | oc create -f -
 apiVersion: machineconfiguration.openshift.io/v1
 kind: MachineConfigPool
 metadata:
-  name: openshift-provider-certification
+  name: opct
 spec:
   machineConfigSelector:
     matchExpressions:

--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,8 @@ module github.com/redhat-openshift-ecosystem/provider-certification-tool
 
 go 1.17
 
+// replace github.com/vmware-tanzu/sonobuoy => /home/mtulio/go/src/github.com/mtulio/sonobuoy
+
 require (
 	github.com/openshift/api v0.0.0-20210910062324-a41d3573a3ba
 	github.com/openshift/client-go v0.0.0-20210521082421-73d9475a9142

--- a/go.mod
+++ b/go.mod
@@ -2,8 +2,6 @@ module github.com/redhat-openshift-ecosystem/provider-certification-tool
 
 go 1.17
 
-// replace github.com/vmware-tanzu/sonobuoy => /home/mtulio/go/src/github.com/mtulio/sonobuoy
-
 require (
 	github.com/openshift/api v0.0.0-20210910062324-a41d3573a3ba
 	github.com/openshift/client-go v0.0.0-20210521082421-73d9475a9142

--- a/manifests/openshift-artifacts-collector.yaml
+++ b/manifests/openshift-artifacts-collector.yaml
@@ -6,10 +6,14 @@ podSpec:
       emptyDir: {}
   containers:
     - name: report-progress
-      image: quay.io/ocp-cert/openshift-tests-provider-cert:dev20230109124258
+      image: quay.io/ocp-cert/openshift-tests-provider-cert:dev20230117180458
       imagePullPolicy: Always
       priorityClassName: system-node-critical
       command: ["./report-progress.sh"]
+      # securityContext:
+      #   privileged: true
+      #   allowPrivilegeEscalation: true
+      #   readOnlyRootFilesystem: false
       volumeMounts:
       - mountPath: /tmp/sonobuoy/results
         name: results
@@ -39,9 +43,13 @@ sonobuoy-config:
   skipCleanup: true
 spec:
   name: plugin
-  image: quay.io/ocp-cert/openshift-tests-provider-cert:dev20230109124258
+  image: quay.io/ocp-cert/openshift-tests-provider-cert:dev20230117180458
   imagePullPolicy: Always
-  priorityClassName: system-node-critical
+  #priorityClassName: system-node-critical
+  # securityContext:
+  #   privileged: true
+  #   allowPrivilegeEscalation: true
+  #   readOnlyRootFilesystem: false
   volumeMounts:
   - mountPath: /tmp/sonobuoy/results
     name: results

--- a/manifests/openshift-artifacts-collector.yaml
+++ b/manifests/openshift-artifacts-collector.yaml
@@ -6,7 +6,7 @@ podSpec:
       emptyDir: {}
   containers:
     - name: report-progress
-      image: quay.io/ocp-cert/openshift-tests-provider-cert:v0.2.1
+      image: quay.io/ocp-cert/openshift-tests-provider-cert:dev20230106125451
       imagePullPolicy: Always
       priorityClassName: system-node-critical
       command: ["./report-progress.sh"]
@@ -39,7 +39,7 @@ sonobuoy-config:
   skipCleanup: true
 spec:
   name: plugin
-  image: quay.io/ocp-cert/openshift-tests-provider-cert:v0.2.1
+  image: quay.io/ocp-cert/openshift-tests-provider-cert:dev20230106125451
   imagePullPolicy: Always
   priorityClassName: system-node-critical
   volumeMounts:

--- a/manifests/openshift-artifacts-collector.yaml
+++ b/manifests/openshift-artifacts-collector.yaml
@@ -6,7 +6,7 @@ podSpec:
       emptyDir: {}
   containers:
     - name: report-progress
-      image: quay.io/ocp-cert/openshift-tests-provider-cert:dev20230124170906
+      image: quay.io/ocp-cert/openshift-tests-provider-cert:v0.3.0-alpha0
       imagePullPolicy: Always
       priorityClassName: system-node-critical
       command: ["./report-progress.sh"]
@@ -39,7 +39,7 @@ sonobuoy-config:
   skipCleanup: true
 spec:
   name: plugin
-  image: quay.io/ocp-cert/openshift-tests-provider-cert:dev20230124170906
+  image: quay.io/ocp-cert/openshift-tests-provider-cert:v0.3.0-alpha0
   imagePullPolicy: Always
   volumeMounts:
   - mountPath: /tmp/sonobuoy/results

--- a/manifests/openshift-artifacts-collector.yaml
+++ b/manifests/openshift-artifacts-collector.yaml
@@ -6,7 +6,7 @@ podSpec:
       emptyDir: {}
   containers:
     - name: report-progress
-      image: quay.io/ocp-cert/openshift-tests-provider-cert:dev20230117180458
+      image: quay.io/ocp-cert/openshift-tests-provider-cert:v0.3.0-dev0
       imagePullPolicy: Always
       priorityClassName: system-node-critical
       command: ["./report-progress.sh"]
@@ -39,7 +39,7 @@ sonobuoy-config:
   skipCleanup: true
 spec:
   name: plugin
-  image: quay.io/ocp-cert/openshift-tests-provider-cert:dev20230117180458
+  image: quay.io/ocp-cert/openshift-tests-provider-cert:v0.3.0-dev0
   imagePullPolicy: Always
   volumeMounts:
   - mountPath: /tmp/sonobuoy/results

--- a/manifests/openshift-artifacts-collector.yaml
+++ b/manifests/openshift-artifacts-collector.yaml
@@ -6,7 +6,7 @@ podSpec:
       emptyDir: {}
   containers:
     - name: report-progress
-      image: quay.io/ocp-cert/openshift-tests-provider-cert:dev20230106125451
+      image: quay.io/ocp-cert/openshift-tests-provider-cert:dev20230109124258
       imagePullPolicy: Always
       priorityClassName: system-node-critical
       command: ["./report-progress.sh"]
@@ -39,7 +39,7 @@ sonobuoy-config:
   skipCleanup: true
 spec:
   name: plugin
-  image: quay.io/ocp-cert/openshift-tests-provider-cert:dev20230106125451
+  image: quay.io/ocp-cert/openshift-tests-provider-cert:dev20230109124258
   imagePullPolicy: Always
   priorityClassName: system-node-critical
   volumeMounts:

--- a/manifests/openshift-artifacts-collector.yaml
+++ b/manifests/openshift-artifacts-collector.yaml
@@ -6,7 +6,7 @@ podSpec:
       emptyDir: {}
   containers:
     - name: report-progress
-      image: quay.io/ocp-cert/openshift-tests-provider-cert:dev20230124153456
+      image: quay.io/ocp-cert/openshift-tests-provider-cert:dev20230124170906
       imagePullPolicy: Always
       priorityClassName: system-node-critical
       command: ["./report-progress.sh"]
@@ -39,7 +39,7 @@ sonobuoy-config:
   skipCleanup: true
 spec:
   name: plugin
-  image: quay.io/ocp-cert/openshift-tests-provider-cert:dev20230124153456
+  image: quay.io/ocp-cert/openshift-tests-provider-cert:dev20230124170906
   imagePullPolicy: Always
   volumeMounts:
   - mountPath: /tmp/sonobuoy/results
@@ -61,3 +61,8 @@ spec:
       valueFrom:
         fieldRef:
           fieldPath: metadata.namespace
+    - name: RUN_MODE
+      valueFrom:
+        configMapKeyRef:
+          name: plugins-config
+          key: run-mode

--- a/manifests/openshift-artifacts-collector.yaml
+++ b/manifests/openshift-artifacts-collector.yaml
@@ -6,7 +6,7 @@ podSpec:
       emptyDir: {}
   containers:
     - name: report-progress
-      image: quay.io/ocp-cert/openshift-tests-provider-cert:v0.3.0-dev0
+      image: quay.io/ocp-cert/openshift-tests-provider-cert:dev20230124153456
       imagePullPolicy: Always
       priorityClassName: system-node-critical
       command: ["./report-progress.sh"]
@@ -39,7 +39,7 @@ sonobuoy-config:
   skipCleanup: true
 spec:
   name: plugin
-  image: quay.io/ocp-cert/openshift-tests-provider-cert:v0.3.0-dev0
+  image: quay.io/ocp-cert/openshift-tests-provider-cert:dev20230124153456
   imagePullPolicy: Always
   volumeMounts:
   - mountPath: /tmp/sonobuoy/results

--- a/manifests/openshift-artifacts-collector.yaml
+++ b/manifests/openshift-artifacts-collector.yaml
@@ -10,10 +10,6 @@ podSpec:
       imagePullPolicy: Always
       priorityClassName: system-node-critical
       command: ["./report-progress.sh"]
-      # securityContext:
-      #   privileged: true
-      #   allowPrivilegeEscalation: true
-      #   readOnlyRootFilesystem: false
       volumeMounts:
       - mountPath: /tmp/sonobuoy/results
         name: results
@@ -45,11 +41,6 @@ spec:
   name: plugin
   image: quay.io/ocp-cert/openshift-tests-provider-cert:dev20230117180458
   imagePullPolicy: Always
-  #priorityClassName: system-node-critical
-  # securityContext:
-  #   privileged: true
-  #   allowPrivilegeEscalation: true
-  #   readOnlyRootFilesystem: false
   volumeMounts:
   - mountPath: /tmp/sonobuoy/results
     name: results

--- a/manifests/openshift-cluster-upgrade.yaml
+++ b/manifests/openshift-cluster-upgrade.yaml
@@ -10,10 +10,6 @@ podSpec:
       imagePullPolicy: Always
       priorityClassName: system-node-critical
       command: ["./report-progress.sh"]
-      # securityContext:
-      #   privileged: true
-      #   allowPrivilegeEscalation: true
-      #   readOnlyRootFilesystem: false
       volumeMounts:
       - mountPath: /tmp/sonobuoy/results
         name: results
@@ -46,10 +42,6 @@ spec:
   image: quay.io/ocp-cert/openshift-tests-provider-cert:dev20230117180458
   imagePullPolicy: Always
   priorityClassName: system-node-critical
-  # securityContext:
-  #   privileged: true
-  #   allowPrivilegeEscalation: true
-  #   readOnlyRootFilesystem: false
   volumeMounts:
   - mountPath: /tmp/sonobuoy/results
     name: results

--- a/manifests/openshift-cluster-upgrade.yaml
+++ b/manifests/openshift-cluster-upgrade.yaml
@@ -6,7 +6,7 @@ podSpec:
       emptyDir: {}
   containers:
     - name: report-progress
-      image: quay.io/ocp-cert/openshift-tests-provider-cert:dev20230124153456
+      image: quay.io/ocp-cert/openshift-tests-provider-cert:dev20230124170906
       imagePullPolicy: Always
       priorityClassName: system-node-critical
       command: ["./report-progress.sh"]
@@ -39,7 +39,7 @@ sonobuoy-config:
   skipCleanup: true
 spec:
   name: plugin
-  image: quay.io/ocp-cert/openshift-tests-provider-cert:dev20230124153456
+  image: quay.io/ocp-cert/openshift-tests-provider-cert:dev20230124170906
   imagePullPolicy: Always
   priorityClassName: system-node-critical
   volumeMounts:

--- a/manifests/openshift-cluster-upgrade.yaml
+++ b/manifests/openshift-cluster-upgrade.yaml
@@ -6,10 +6,14 @@ podSpec:
       emptyDir: {}
   containers:
     - name: report-progress
-      image: quay.io/ocp-cert/openshift-tests-provider-cert:dev20230109124258
+      image: quay.io/ocp-cert/openshift-tests-provider-cert:dev20230117180458
       imagePullPolicy: Always
       priorityClassName: system-node-critical
       command: ["./report-progress.sh"]
+      # securityContext:
+      #   privileged: true
+      #   allowPrivilegeEscalation: true
+      #   readOnlyRootFilesystem: false
       volumeMounts:
       - mountPath: /tmp/sonobuoy/results
         name: results
@@ -39,9 +43,13 @@ sonobuoy-config:
   skipCleanup: true
 spec:
   name: plugin
-  image: quay.io/ocp-cert/openshift-tests-provider-cert:dev20230109124258
+  image: quay.io/ocp-cert/openshift-tests-provider-cert:dev20230117180458
   imagePullPolicy: Always
   priorityClassName: system-node-critical
+  # securityContext:
+  #   privileged: true
+  #   allowPrivilegeEscalation: true
+  #   readOnlyRootFilesystem: false
   volumeMounts:
   - mountPath: /tmp/sonobuoy/results
     name: results
@@ -62,8 +70,6 @@ spec:
       valueFrom:
         fieldRef:
           fieldPath: metadata.namespace
-    - name: RUN_MODE
-      value: upgrade
     - name: UPGRADE_RELEASES
       valueFrom:
         configMapKeyRef:

--- a/manifests/openshift-cluster-upgrade.yaml
+++ b/manifests/openshift-cluster-upgrade.yaml
@@ -32,7 +32,7 @@ podSpec:
               fieldPath: metadata.namespace
 sonobuoy-config:
   driver: Job
-  plugin-name: 01-openshift-cluster-upgrade
+  plugin-name: 05-openshift-cluster-upgrade
   result-format: junit
   description: The end-to-end tests maintained by OpenShift to certify the Provider running the OpenShift Container Platform.
   source-url: https://github.com/redhat-openshift-ecosystem/provider-certification-tool/blob/main/manifests/openshift-conformance-validated.yaml
@@ -68,7 +68,7 @@ spec:
       valueFrom:
         configMapKeyRef:
           name: plugins-config
-          key: upgrade-target-image
+          key: upgrade-target-images
     - name: RUN_MODE
       valueFrom:
         configMapKeyRef:

--- a/manifests/openshift-cluster-upgrade.yaml
+++ b/manifests/openshift-cluster-upgrade.yaml
@@ -6,7 +6,7 @@ podSpec:
       emptyDir: {}
   containers:
     - name: report-progress
-      image: quay.io/ocp-cert/openshift-tests-provider-cert:devel
+      image: quay.io/ocp-cert/openshift-tests-provider-cert:dev20230106125451
       imagePullPolicy: Always
       priorityClassName: system-node-critical
       command: ["./report-progress.sh"]
@@ -39,7 +39,7 @@ sonobuoy-config:
   skipCleanup: true
 spec:
   name: plugin
-  image: quay.io/ocp-cert/openshift-tests-provider-cert:devel
+  image: quay.io/ocp-cert/openshift-tests-provider-cert:dev20230106125451
   imagePullPolicy: Always
   priorityClassName: system-node-critical
   volumeMounts:

--- a/manifests/openshift-cluster-upgrade.yaml
+++ b/manifests/openshift-cluster-upgrade.yaml
@@ -6,7 +6,7 @@ podSpec:
       emptyDir: {}
   containers:
     - name: report-progress
-      image: quay.io/ocp-cert/openshift-tests-provider-cert:v0.3.0-dev0
+      image: quay.io/ocp-cert/openshift-tests-provider-cert:dev20230124153456
       imagePullPolicy: Always
       priorityClassName: system-node-critical
       command: ["./report-progress.sh"]
@@ -39,7 +39,7 @@ sonobuoy-config:
   skipCleanup: true
 spec:
   name: plugin
-  image: quay.io/ocp-cert/openshift-tests-provider-cert:v0.3.0-dev0
+  image: quay.io/ocp-cert/openshift-tests-provider-cert:dev20230124153456
   imagePullPolicy: Always
   priorityClassName: system-node-critical
   volumeMounts:

--- a/manifests/openshift-cluster-upgrade.yaml
+++ b/manifests/openshift-cluster-upgrade.yaml
@@ -6,7 +6,7 @@ podSpec:
       emptyDir: {}
   containers:
     - name: report-progress
-      image: quay.io/ocp-cert/openshift-tests-provider-cert:dev20230106125451
+      image: quay.io/ocp-cert/openshift-tests-provider-cert:dev20230109124258
       imagePullPolicy: Always
       priorityClassName: system-node-critical
       command: ["./report-progress.sh"]
@@ -39,7 +39,7 @@ sonobuoy-config:
   skipCleanup: true
 spec:
   name: plugin
-  image: quay.io/ocp-cert/openshift-tests-provider-cert:dev20230106125451
+  image: quay.io/ocp-cert/openshift-tests-provider-cert:dev20230109124258
   imagePullPolicy: Always
   priorityClassName: system-node-critical
   volumeMounts:

--- a/manifests/openshift-cluster-upgrade.yaml
+++ b/manifests/openshift-cluster-upgrade.yaml
@@ -1,0 +1,76 @@
+podSpec:
+  restartPolicy: Never
+  serviceAccountName: sonobuoy-serviceaccount
+  volumes:
+    - name: shared
+      emptyDir: {}
+  containers:
+    - name: report-progress
+      image: quay.io/ocp-cert/openshift-tests-provider-cert:devel
+      imagePullPolicy: Always
+      priorityClassName: system-node-critical
+      command: ["./report-progress.sh"]
+      volumeMounts:
+      - mountPath: /tmp/sonobuoy/results
+        name: results
+      - mountPath: /tmp/shared
+        name: shared
+      env:
+        - name: PLUGIN_ID
+          value: "05"
+        - name: ENV_NODE_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
+        - name: ENV_POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: ENV_POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+sonobuoy-config:
+  driver: Job
+  plugin-name: 01-openshift-cluster-upgrade
+  result-format: junit
+  description: The end-to-end tests maintained by OpenShift to certify the Provider running the OpenShift Container Platform.
+  source-url: https://github.com/redhat-openshift-ecosystem/provider-certification-tool/blob/main/manifests/openshift-conformance-validated.yaml
+  skipCleanup: true
+spec:
+  name: plugin
+  image: quay.io/ocp-cert/openshift-tests-provider-cert:devel
+  imagePullPolicy: Always
+  priorityClassName: system-node-critical
+  volumeMounts:
+  - mountPath: /tmp/sonobuoy/results
+    name: results
+  - mountPath: /tmp/shared
+    name: shared
+  env:
+    - name: PLUGIN_ID
+      value: "05"
+    - name: ENV_NODE_NAME
+      valueFrom:
+        fieldRef:
+          fieldPath: spec.nodeName
+    - name: ENV_POD_NAME
+      valueFrom:
+        fieldRef:
+          fieldPath: metadata.name
+    - name: ENV_POD_NAMESPACE
+      valueFrom:
+        fieldRef:
+          fieldPath: metadata.namespace
+    - name: RUN_MODE
+      value: upgrade
+    - name: UPGRADE_RELEASES
+      valueFrom:
+        configMapKeyRef:
+          name: plugins-config
+          key: upgrade-target-image
+    - name: RUN_MODE
+      valueFrom:
+        configMapKeyRef:
+          name: plugins-config
+          key: run-mode

--- a/manifests/openshift-cluster-upgrade.yaml
+++ b/manifests/openshift-cluster-upgrade.yaml
@@ -6,7 +6,7 @@ podSpec:
       emptyDir: {}
   containers:
     - name: report-progress
-      image: quay.io/ocp-cert/openshift-tests-provider-cert:dev20230117180458
+      image: quay.io/ocp-cert/openshift-tests-provider-cert:v0.3.0-dev0
       imagePullPolicy: Always
       priorityClassName: system-node-critical
       command: ["./report-progress.sh"]
@@ -39,7 +39,7 @@ sonobuoy-config:
   skipCleanup: true
 spec:
   name: plugin
-  image: quay.io/ocp-cert/openshift-tests-provider-cert:dev20230117180458
+  image: quay.io/ocp-cert/openshift-tests-provider-cert:v0.3.0-dev0
   imagePullPolicy: Always
   priorityClassName: system-node-critical
   volumeMounts:

--- a/manifests/openshift-cluster-upgrade.yaml
+++ b/manifests/openshift-cluster-upgrade.yaml
@@ -6,7 +6,7 @@ podSpec:
       emptyDir: {}
   containers:
     - name: report-progress
-      image: quay.io/ocp-cert/openshift-tests-provider-cert:dev20230124170906
+      image: quay.io/ocp-cert/openshift-tests-provider-cert:v0.3.0-alpha0
       imagePullPolicy: Always
       priorityClassName: system-node-critical
       command: ["./report-progress.sh"]
@@ -39,7 +39,7 @@ sonobuoy-config:
   skipCleanup: true
 spec:
   name: plugin
-  image: quay.io/ocp-cert/openshift-tests-provider-cert:dev20230124170906
+  image: quay.io/ocp-cert/openshift-tests-provider-cert:v0.3.0-alpha0
   imagePullPolicy: Always
   priorityClassName: system-node-critical
   volumeMounts:

--- a/manifests/openshift-conformance-validated.yaml
+++ b/manifests/openshift-conformance-validated.yaml
@@ -6,7 +6,7 @@ podSpec:
       emptyDir: {}
   containers:
     - name: report-progress
-      image: quay.io/ocp-cert/openshift-tests-provider-cert:dev20230124153456
+      image: quay.io/ocp-cert/openshift-tests-provider-cert:dev20230124170906
       imagePullPolicy: Always
       priorityClassName: system-node-critical
       command: ["./report-progress.sh"]
@@ -39,7 +39,7 @@ sonobuoy-config:
   skipCleanup: true
 spec:
   name: plugin
-  image: quay.io/ocp-cert/openshift-tests-provider-cert:dev20230124153456
+  image: quay.io/ocp-cert/openshift-tests-provider-cert:dev20230124170906
   imagePullPolicy: Always
   priorityClassName: system-node-critical
   volumeMounts:

--- a/manifests/openshift-conformance-validated.yaml
+++ b/manifests/openshift-conformance-validated.yaml
@@ -6,7 +6,7 @@ podSpec:
       emptyDir: {}
   containers:
     - name: report-progress
-      image: quay.io/ocp-cert/openshift-tests-provider-cert:v0.2.1
+      image: quay.io/ocp-cert/openshift-tests-provider-cert:dev20230106125451
       imagePullPolicy: Always
       priorityClassName: system-node-critical
       command: ["./report-progress.sh"]
@@ -39,7 +39,7 @@ sonobuoy-config:
   skipCleanup: true
 spec:
   name: plugin
-  image: quay.io/ocp-cert/openshift-tests-provider-cert:v0.2.1
+  image: quay.io/ocp-cert/openshift-tests-provider-cert:dev20230106125451
   imagePullPolicy: Always
   priorityClassName: system-node-critical
   volumeMounts:

--- a/manifests/openshift-conformance-validated.yaml
+++ b/manifests/openshift-conformance-validated.yaml
@@ -10,10 +10,6 @@ podSpec:
       imagePullPolicy: Always
       priorityClassName: system-node-critical
       command: ["./report-progress.sh"]
-      # securityContext:
-      #   privileged: true
-      #   allowPrivilegeEscalation: true
-      #   readOnlyRootFilesystem: false
       volumeMounts:
       - mountPath: /tmp/sonobuoy/results
         name: results
@@ -46,10 +42,6 @@ spec:
   image: quay.io/ocp-cert/openshift-tests-provider-cert:dev20230117180458
   imagePullPolicy: Always
   priorityClassName: system-node-critical
-  # securityContext:
-  #   privileged: true
-  #   allowPrivilegeEscalation: true
-  #   readOnlyRootFilesystem: false
   volumeMounts:
   - mountPath: /tmp/sonobuoy/results
     name: results
@@ -70,8 +62,3 @@ spec:
       valueFrom:
         fieldRef:
           fieldPath: metadata.namespace
-    - name: DEV_MODE_COUNT
-      valueFrom:
-        configMapKeyRef:
-          name: plugins-config
-          key: dev-count

--- a/manifests/openshift-conformance-validated.yaml
+++ b/manifests/openshift-conformance-validated.yaml
@@ -6,7 +6,7 @@ podSpec:
       emptyDir: {}
   containers:
     - name: report-progress
-      image: quay.io/ocp-cert/openshift-tests-provider-cert:v0.3.0-dev0
+      image: quay.io/ocp-cert/openshift-tests-provider-cert:dev20230124153456
       imagePullPolicy: Always
       priorityClassName: system-node-critical
       command: ["./report-progress.sh"]
@@ -39,7 +39,7 @@ sonobuoy-config:
   skipCleanup: true
 spec:
   name: plugin
-  image: quay.io/ocp-cert/openshift-tests-provider-cert:v0.3.0-dev0
+  image: quay.io/ocp-cert/openshift-tests-provider-cert:dev20230124153456
   imagePullPolicy: Always
   priorityClassName: system-node-critical
   volumeMounts:

--- a/manifests/openshift-conformance-validated.yaml
+++ b/manifests/openshift-conformance-validated.yaml
@@ -6,7 +6,7 @@ podSpec:
       emptyDir: {}
   containers:
     - name: report-progress
-      image: quay.io/ocp-cert/openshift-tests-provider-cert:dev20230106125451
+      image: quay.io/ocp-cert/openshift-tests-provider-cert:dev20230109124258
       imagePullPolicy: Always
       priorityClassName: system-node-critical
       command: ["./report-progress.sh"]
@@ -39,7 +39,7 @@ sonobuoy-config:
   skipCleanup: true
 spec:
   name: plugin
-  image: quay.io/ocp-cert/openshift-tests-provider-cert:dev20230106125451
+  image: quay.io/ocp-cert/openshift-tests-provider-cert:dev20230109124258
   imagePullPolicy: Always
   priorityClassName: system-node-critical
   volumeMounts:

--- a/manifests/openshift-conformance-validated.yaml
+++ b/manifests/openshift-conformance-validated.yaml
@@ -62,3 +62,8 @@ spec:
       valueFrom:
         fieldRef:
           fieldPath: metadata.namespace
+    - name: DEV_MODE_COUNT
+      valueFrom:
+        configMapKeyRef:
+          name: plugins-config
+          key: dev-count

--- a/manifests/openshift-conformance-validated.yaml
+++ b/manifests/openshift-conformance-validated.yaml
@@ -6,10 +6,14 @@ podSpec:
       emptyDir: {}
   containers:
     - name: report-progress
-      image: quay.io/ocp-cert/openshift-tests-provider-cert:dev20230109124258
+      image: quay.io/ocp-cert/openshift-tests-provider-cert:dev20230117180458
       imagePullPolicy: Always
       priorityClassName: system-node-critical
       command: ["./report-progress.sh"]
+      # securityContext:
+      #   privileged: true
+      #   allowPrivilegeEscalation: true
+      #   readOnlyRootFilesystem: false
       volumeMounts:
       - mountPath: /tmp/sonobuoy/results
         name: results
@@ -39,9 +43,13 @@ sonobuoy-config:
   skipCleanup: true
 spec:
   name: plugin
-  image: quay.io/ocp-cert/openshift-tests-provider-cert:dev20230109124258
+  image: quay.io/ocp-cert/openshift-tests-provider-cert:dev20230117180458
   imagePullPolicy: Always
   priorityClassName: system-node-critical
+  # securityContext:
+  #   privileged: true
+  #   allowPrivilegeEscalation: true
+  #   readOnlyRootFilesystem: false
   volumeMounts:
   - mountPath: /tmp/sonobuoy/results
     name: results

--- a/manifests/openshift-conformance-validated.yaml
+++ b/manifests/openshift-conformance-validated.yaml
@@ -62,6 +62,11 @@ spec:
       valueFrom:
         fieldRef:
           fieldPath: metadata.namespace
+    - name: RUN_MODE
+      valueFrom:
+        configMapKeyRef:
+          name: plugins-config
+          key: run-mode
     - name: DEV_MODE_COUNT
       valueFrom:
         configMapKeyRef:

--- a/manifests/openshift-conformance-validated.yaml
+++ b/manifests/openshift-conformance-validated.yaml
@@ -6,7 +6,7 @@ podSpec:
       emptyDir: {}
   containers:
     - name: report-progress
-      image: quay.io/ocp-cert/openshift-tests-provider-cert:dev20230117180458
+      image: quay.io/ocp-cert/openshift-tests-provider-cert:v0.3.0-dev0
       imagePullPolicy: Always
       priorityClassName: system-node-critical
       command: ["./report-progress.sh"]
@@ -39,7 +39,7 @@ sonobuoy-config:
   skipCleanup: true
 spec:
   name: plugin
-  image: quay.io/ocp-cert/openshift-tests-provider-cert:dev20230117180458
+  image: quay.io/ocp-cert/openshift-tests-provider-cert:v0.3.0-dev0
   imagePullPolicy: Always
   priorityClassName: system-node-critical
   volumeMounts:

--- a/manifests/openshift-conformance-validated.yaml
+++ b/manifests/openshift-conformance-validated.yaml
@@ -6,7 +6,7 @@ podSpec:
       emptyDir: {}
   containers:
     - name: report-progress
-      image: quay.io/ocp-cert/openshift-tests-provider-cert:dev20230124170906
+      image: quay.io/ocp-cert/openshift-tests-provider-cert:v0.3.0-alpha0
       imagePullPolicy: Always
       priorityClassName: system-node-critical
       command: ["./report-progress.sh"]
@@ -39,7 +39,7 @@ sonobuoy-config:
   skipCleanup: true
 spec:
   name: plugin
-  image: quay.io/ocp-cert/openshift-tests-provider-cert:dev20230124170906
+  image: quay.io/ocp-cert/openshift-tests-provider-cert:v0.3.0-alpha0
   imagePullPolicy: Always
   priorityClassName: system-node-critical
   volumeMounts:

--- a/manifests/openshift-kube-conformance.yaml
+++ b/manifests/openshift-kube-conformance.yaml
@@ -6,7 +6,7 @@ podSpec:
       emptyDir: {}
   containers:
     - name: report-progress
-      image: quay.io/ocp-cert/openshift-tests-provider-cert:dev20230124153456
+      image: quay.io/ocp-cert/openshift-tests-provider-cert:dev20230124170906
       imagePullPolicy: Always
       priorityClassName: system-node-critical
       command: ["./report-progress.sh"]
@@ -39,7 +39,7 @@ sonobuoy-config:
   skipCleanup: true
 spec:
   name: plugin
-  image: quay.io/ocp-cert/openshift-tests-provider-cert:dev20230124153456
+  image: quay.io/ocp-cert/openshift-tests-provider-cert:dev20230124170906
   imagePullPolicy: Always
   priorityClassName: system-node-critical
   volumeMounts:

--- a/manifests/openshift-kube-conformance.yaml
+++ b/manifests/openshift-kube-conformance.yaml
@@ -6,7 +6,7 @@ podSpec:
       emptyDir: {}
   containers:
     - name: report-progress
-      image: quay.io/ocp-cert/openshift-tests-provider-cert:v0.2.1
+      image: quay.io/ocp-cert/openshift-tests-provider-cert:dev20230106125451
       imagePullPolicy: Always
       priorityClassName: system-node-critical
       command: ["./report-progress.sh"]
@@ -39,7 +39,7 @@ sonobuoy-config:
   skipCleanup: true
 spec:
   name: plugin
-  image: quay.io/ocp-cert/openshift-tests-provider-cert:v0.2.1
+  image: quay.io/ocp-cert/openshift-tests-provider-cert:dev20230106125451
   imagePullPolicy: Always
   priorityClassName: system-node-critical
   volumeMounts:

--- a/manifests/openshift-kube-conformance.yaml
+++ b/manifests/openshift-kube-conformance.yaml
@@ -10,10 +10,6 @@ podSpec:
       imagePullPolicy: Always
       priorityClassName: system-node-critical
       command: ["./report-progress.sh"]
-      # securityContext:
-      #   privileged: true
-      #   allowPrivilegeEscalation: true
-      #   readOnlyRootFilesystem: false
       volumeMounts:
       - mountPath: /tmp/sonobuoy/results
         name: results
@@ -46,10 +42,6 @@ spec:
   image: quay.io/ocp-cert/openshift-tests-provider-cert:dev20230117180458
   imagePullPolicy: Always
   priorityClassName: system-node-critical
-  # securityContext:
-  #   privileged: true
-  #   allowPrivilegeEscalation: true
-  #   readOnlyRootFilesystem: false
   volumeMounts:
   - mountPath: /tmp/sonobuoy/results
     name: results
@@ -70,8 +62,3 @@ spec:
       valueFrom:
         fieldRef:
           fieldPath: metadata.namespace
-    - name: DEV_MODE_COUNT
-      valueFrom:
-        configMapKeyRef:
-          name: plugins-config
-          key: dev-count

--- a/manifests/openshift-kube-conformance.yaml
+++ b/manifests/openshift-kube-conformance.yaml
@@ -6,7 +6,7 @@ podSpec:
       emptyDir: {}
   containers:
     - name: report-progress
-      image: quay.io/ocp-cert/openshift-tests-provider-cert:v0.3.0-dev0
+      image: quay.io/ocp-cert/openshift-tests-provider-cert:dev20230124153456
       imagePullPolicy: Always
       priorityClassName: system-node-critical
       command: ["./report-progress.sh"]
@@ -39,7 +39,7 @@ sonobuoy-config:
   skipCleanup: true
 spec:
   name: plugin
-  image: quay.io/ocp-cert/openshift-tests-provider-cert:v0.3.0-dev0
+  image: quay.io/ocp-cert/openshift-tests-provider-cert:dev20230124153456
   imagePullPolicy: Always
   priorityClassName: system-node-critical
   volumeMounts:

--- a/manifests/openshift-kube-conformance.yaml
+++ b/manifests/openshift-kube-conformance.yaml
@@ -6,7 +6,7 @@ podSpec:
       emptyDir: {}
   containers:
     - name: report-progress
-      image: quay.io/ocp-cert/openshift-tests-provider-cert:dev20230106125451
+      image: quay.io/ocp-cert/openshift-tests-provider-cert:dev20230109124258
       imagePullPolicy: Always
       priorityClassName: system-node-critical
       command: ["./report-progress.sh"]
@@ -39,7 +39,7 @@ sonobuoy-config:
   skipCleanup: true
 spec:
   name: plugin
-  image: quay.io/ocp-cert/openshift-tests-provider-cert:dev20230106125451
+  image: quay.io/ocp-cert/openshift-tests-provider-cert:dev20230109124258
   imagePullPolicy: Always
   priorityClassName: system-node-critical
   volumeMounts:

--- a/manifests/openshift-kube-conformance.yaml
+++ b/manifests/openshift-kube-conformance.yaml
@@ -62,3 +62,8 @@ spec:
       valueFrom:
         fieldRef:
           fieldPath: metadata.namespace
+    - name: DEV_MODE_COUNT
+      valueFrom:
+        configMapKeyRef:
+          name: plugins-config
+          key: dev-count

--- a/manifests/openshift-kube-conformance.yaml
+++ b/manifests/openshift-kube-conformance.yaml
@@ -6,10 +6,14 @@ podSpec:
       emptyDir: {}
   containers:
     - name: report-progress
-      image: quay.io/ocp-cert/openshift-tests-provider-cert:dev20230109124258
+      image: quay.io/ocp-cert/openshift-tests-provider-cert:dev20230117180458
       imagePullPolicy: Always
       priorityClassName: system-node-critical
       command: ["./report-progress.sh"]
+      # securityContext:
+      #   privileged: true
+      #   allowPrivilegeEscalation: true
+      #   readOnlyRootFilesystem: false
       volumeMounts:
       - mountPath: /tmp/sonobuoy/results
         name: results
@@ -39,9 +43,13 @@ sonobuoy-config:
   skipCleanup: true
 spec:
   name: plugin
-  image: quay.io/ocp-cert/openshift-tests-provider-cert:dev20230109124258
+  image: quay.io/ocp-cert/openshift-tests-provider-cert:dev20230117180458
   imagePullPolicy: Always
   priorityClassName: system-node-critical
+  # securityContext:
+  #   privileged: true
+  #   allowPrivilegeEscalation: true
+  #   readOnlyRootFilesystem: false
   volumeMounts:
   - mountPath: /tmp/sonobuoy/results
     name: results

--- a/manifests/openshift-kube-conformance.yaml
+++ b/manifests/openshift-kube-conformance.yaml
@@ -62,6 +62,11 @@ spec:
       valueFrom:
         fieldRef:
           fieldPath: metadata.namespace
+    - name: RUN_MODE
+      valueFrom:
+        configMapKeyRef:
+          name: plugins-config
+          key: run-mode
     - name: DEV_MODE_COUNT
       valueFrom:
         configMapKeyRef:

--- a/manifests/openshift-kube-conformance.yaml
+++ b/manifests/openshift-kube-conformance.yaml
@@ -6,7 +6,7 @@ podSpec:
       emptyDir: {}
   containers:
     - name: report-progress
-      image: quay.io/ocp-cert/openshift-tests-provider-cert:dev20230117180458
+      image: quay.io/ocp-cert/openshift-tests-provider-cert:v0.3.0-dev0
       imagePullPolicy: Always
       priorityClassName: system-node-critical
       command: ["./report-progress.sh"]
@@ -39,7 +39,7 @@ sonobuoy-config:
   skipCleanup: true
 spec:
   name: plugin
-  image: quay.io/ocp-cert/openshift-tests-provider-cert:dev20230117180458
+  image: quay.io/ocp-cert/openshift-tests-provider-cert:v0.3.0-dev0
   imagePullPolicy: Always
   priorityClassName: system-node-critical
   volumeMounts:

--- a/manifests/openshift-kube-conformance.yaml
+++ b/manifests/openshift-kube-conformance.yaml
@@ -6,7 +6,7 @@ podSpec:
       emptyDir: {}
   containers:
     - name: report-progress
-      image: quay.io/ocp-cert/openshift-tests-provider-cert:dev20230124170906
+      image: quay.io/ocp-cert/openshift-tests-provider-cert:v0.3.0-alpha0
       imagePullPolicy: Always
       priorityClassName: system-node-critical
       command: ["./report-progress.sh"]
@@ -39,7 +39,7 @@ sonobuoy-config:
   skipCleanup: true
 spec:
   name: plugin
-  image: quay.io/ocp-cert/openshift-tests-provider-cert:dev20230124170906
+  image: quay.io/ocp-cert/openshift-tests-provider-cert:v0.3.0-alpha0
   imagePullPolicy: Always
   priorityClassName: system-node-critical
   volumeMounts:

--- a/pkg/assets/bindata.go
+++ b/pkg/assets/bindata.go
@@ -64,7 +64,7 @@ var _manifestsOpenshiftArtifactsCollectorYaml = []byte(`podSpec:
       emptyDir: {}
   containers:
     - name: report-progress
-      image: quay.io/ocp-cert/openshift-tests-provider-cert:dev20230106125451
+      image: quay.io/ocp-cert/openshift-tests-provider-cert:dev20230109124258
       imagePullPolicy: Always
       priorityClassName: system-node-critical
       command: ["./report-progress.sh"]
@@ -97,7 +97,7 @@ sonobuoy-config:
   skipCleanup: true
 spec:
   name: plugin
-  image: quay.io/ocp-cert/openshift-tests-provider-cert:dev20230106125451
+  image: quay.io/ocp-cert/openshift-tests-provider-cert:dev20230109124258
   imagePullPolicy: Always
   priorityClassName: system-node-critical
   volumeMounts:
@@ -145,7 +145,7 @@ var _manifestsOpenshiftClusterUpgradeYaml = []byte(`podSpec:
       emptyDir: {}
   containers:
     - name: report-progress
-      image: quay.io/ocp-cert/openshift-tests-provider-cert:dev20230106125451
+      image: quay.io/ocp-cert/openshift-tests-provider-cert:dev20230109124258
       imagePullPolicy: Always
       priorityClassName: system-node-critical
       command: ["./report-progress.sh"]
@@ -178,7 +178,7 @@ sonobuoy-config:
   skipCleanup: true
 spec:
   name: plugin
-  image: quay.io/ocp-cert/openshift-tests-provider-cert:dev20230106125451
+  image: quay.io/ocp-cert/openshift-tests-provider-cert:dev20230109124258
   imagePullPolicy: Always
   priorityClassName: system-node-critical
   volumeMounts:
@@ -238,7 +238,7 @@ var _manifestsOpenshiftConformanceValidatedYaml = []byte(`podSpec:
       emptyDir: {}
   containers:
     - name: report-progress
-      image: quay.io/ocp-cert/openshift-tests-provider-cert:dev20230106125451
+      image: quay.io/ocp-cert/openshift-tests-provider-cert:dev20230109124258
       imagePullPolicy: Always
       priorityClassName: system-node-critical
       command: ["./report-progress.sh"]
@@ -271,7 +271,7 @@ sonobuoy-config:
   skipCleanup: true
 spec:
   name: plugin
-  image: quay.io/ocp-cert/openshift-tests-provider-cert:dev20230106125451
+  image: quay.io/ocp-cert/openshift-tests-provider-cert:dev20230109124258
   imagePullPolicy: Always
   priorityClassName: system-node-critical
   volumeMounts:
@@ -324,7 +324,7 @@ var _manifestsOpenshiftKubeConformanceYaml = []byte(`podSpec:
       emptyDir: {}
   containers:
     - name: report-progress
-      image: quay.io/ocp-cert/openshift-tests-provider-cert:dev20230106125451
+      image: quay.io/ocp-cert/openshift-tests-provider-cert:dev20230109124258
       imagePullPolicy: Always
       priorityClassName: system-node-critical
       command: ["./report-progress.sh"]
@@ -357,7 +357,7 @@ sonobuoy-config:
   skipCleanup: true
 spec:
   name: plugin
-  image: quay.io/ocp-cert/openshift-tests-provider-cert:dev20230106125451
+  image: quay.io/ocp-cert/openshift-tests-provider-cert:dev20230109124258
   imagePullPolicy: Always
   priorityClassName: system-node-critical
   volumeMounts:

--- a/pkg/assets/bindata.go
+++ b/pkg/assets/bindata.go
@@ -291,6 +291,11 @@ spec:
       valueFrom:
         fieldRef:
           fieldPath: metadata.namespace
+    - name: DEV_MODE_COUNT
+      valueFrom:
+        configMapKeyRef:
+          name: plugins-config
+          key: dev-count
 `)
 
 func manifestsOpenshiftConformanceValidatedYamlBytes() ([]byte, error) {
@@ -372,6 +377,11 @@ spec:
       valueFrom:
         fieldRef:
           fieldPath: metadata.namespace
+    - name: DEV_MODE_COUNT
+      valueFrom:
+        configMapKeyRef:
+          name: plugins-config
+          key: dev-count
 `)
 
 func manifestsOpenshiftKubeConformanceYamlBytes() ([]byte, error) {

--- a/pkg/assets/bindata.go
+++ b/pkg/assets/bindata.go
@@ -1,6 +1,7 @@
 // Code generated for package assets by go-bindata DO NOT EDIT. (@generated)
 // sources:
 // manifests/openshift-artifacts-collector.yaml
+// manifests/openshift-cluster-upgrade.yaml
 // manifests/openshift-conformance-validated.yaml
 // manifests/openshift-kube-conformance.yaml
 package assets
@@ -132,6 +133,99 @@ func manifestsOpenshiftArtifactsCollectorYaml() (*asset, error) {
 	}
 
 	info := bindataFileInfo{name: "manifests/openshift-artifacts-collector.yaml", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
+	a := &asset{bytes: bytes, info: info}
+	return a, nil
+}
+
+var _manifestsOpenshiftClusterUpgradeYaml = []byte(`podSpec:
+  restartPolicy: Never
+  serviceAccountName: sonobuoy-serviceaccount
+  volumes:
+    - name: shared
+      emptyDir: {}
+  containers:
+    - name: report-progress
+      image: quay.io/ocp-cert/openshift-tests-provider-cert:devel
+      imagePullPolicy: Always
+      priorityClassName: system-node-critical
+      command: ["./report-progress.sh"]
+      volumeMounts:
+      - mountPath: /tmp/sonobuoy/results
+        name: results
+      - mountPath: /tmp/shared
+        name: shared
+      env:
+        - name: PLUGIN_ID
+          value: "05"
+        - name: ENV_NODE_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
+        - name: ENV_POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: ENV_POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+sonobuoy-config:
+  driver: Job
+  plugin-name: 01-openshift-cluster-upgrade
+  result-format: junit
+  description: The end-to-end tests maintained by OpenShift to certify the Provider running the OpenShift Container Platform.
+  source-url: https://github.com/redhat-openshift-ecosystem/provider-certification-tool/blob/main/manifests/openshift-conformance-validated.yaml
+  skipCleanup: true
+spec:
+  name: plugin
+  image: quay.io/ocp-cert/openshift-tests-provider-cert:devel
+  imagePullPolicy: Always
+  priorityClassName: system-node-critical
+  volumeMounts:
+  - mountPath: /tmp/sonobuoy/results
+    name: results
+  - mountPath: /tmp/shared
+    name: shared
+  env:
+    - name: PLUGIN_ID
+      value: "05"
+    - name: ENV_NODE_NAME
+      valueFrom:
+        fieldRef:
+          fieldPath: spec.nodeName
+    - name: ENV_POD_NAME
+      valueFrom:
+        fieldRef:
+          fieldPath: metadata.name
+    - name: ENV_POD_NAMESPACE
+      valueFrom:
+        fieldRef:
+          fieldPath: metadata.namespace
+    - name: RUN_MODE
+      value: upgrade
+    - name: UPGRADE_RELEASES
+      valueFrom:
+        configMapKeyRef:
+          name: plugins-config
+          key: upgrade-target-image
+    - name: RUN_MODE
+      valueFrom:
+        configMapKeyRef:
+          name: plugins-config
+          key: run-mode
+`)
+
+func manifestsOpenshiftClusterUpgradeYamlBytes() ([]byte, error) {
+	return _manifestsOpenshiftClusterUpgradeYaml, nil
+}
+
+func manifestsOpenshiftClusterUpgradeYaml() (*asset, error) {
+	bytes, err := manifestsOpenshiftClusterUpgradeYamlBytes()
+	if err != nil {
+		return nil, err
+	}
+
+	info := bindataFileInfo{name: "manifests/openshift-cluster-upgrade.yaml", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -361,6 +455,7 @@ func AssetNames() []string {
 // _bindata is a table, holding each asset generator, mapped to its name.
 var _bindata = map[string]func() (*asset, error){
 	"manifests/openshift-artifacts-collector.yaml":   manifestsOpenshiftArtifactsCollectorYaml,
+	"manifests/openshift-cluster-upgrade.yaml":       manifestsOpenshiftClusterUpgradeYaml,
 	"manifests/openshift-conformance-validated.yaml": manifestsOpenshiftConformanceValidatedYaml,
 	"manifests/openshift-kube-conformance.yaml":      manifestsOpenshiftKubeConformanceYaml,
 }
@@ -408,6 +503,7 @@ type bintree struct {
 var _bintree = &bintree{nil, map[string]*bintree{
 	"manifests": &bintree{nil, map[string]*bintree{
 		"openshift-artifacts-collector.yaml":   &bintree{manifestsOpenshiftArtifactsCollectorYaml, map[string]*bintree{}},
+		"openshift-cluster-upgrade.yaml":       &bintree{manifestsOpenshiftClusterUpgradeYaml, map[string]*bintree{}},
 		"openshift-conformance-validated.yaml": &bintree{manifestsOpenshiftConformanceValidatedYaml, map[string]*bintree{}},
 		"openshift-kube-conformance.yaml":      &bintree{manifestsOpenshiftKubeConformanceYaml, map[string]*bintree{}},
 	}},

--- a/pkg/assets/bindata.go
+++ b/pkg/assets/bindata.go
@@ -64,7 +64,7 @@ var _manifestsOpenshiftArtifactsCollectorYaml = []byte(`podSpec:
       emptyDir: {}
   containers:
     - name: report-progress
-      image: quay.io/ocp-cert/openshift-tests-provider-cert:v0.2.1
+      image: quay.io/ocp-cert/openshift-tests-provider-cert:dev20230106125451
       imagePullPolicy: Always
       priorityClassName: system-node-critical
       command: ["./report-progress.sh"]
@@ -97,7 +97,7 @@ sonobuoy-config:
   skipCleanup: true
 spec:
   name: plugin
-  image: quay.io/ocp-cert/openshift-tests-provider-cert:v0.2.1
+  image: quay.io/ocp-cert/openshift-tests-provider-cert:dev20230106125451
   imagePullPolicy: Always
   priorityClassName: system-node-critical
   volumeMounts:
@@ -145,7 +145,7 @@ var _manifestsOpenshiftClusterUpgradeYaml = []byte(`podSpec:
       emptyDir: {}
   containers:
     - name: report-progress
-      image: quay.io/ocp-cert/openshift-tests-provider-cert:devel
+      image: quay.io/ocp-cert/openshift-tests-provider-cert:dev20230106125451
       imagePullPolicy: Always
       priorityClassName: system-node-critical
       command: ["./report-progress.sh"]
@@ -178,7 +178,7 @@ sonobuoy-config:
   skipCleanup: true
 spec:
   name: plugin
-  image: quay.io/ocp-cert/openshift-tests-provider-cert:devel
+  image: quay.io/ocp-cert/openshift-tests-provider-cert:dev20230106125451
   imagePullPolicy: Always
   priorityClassName: system-node-critical
   volumeMounts:
@@ -238,7 +238,7 @@ var _manifestsOpenshiftConformanceValidatedYaml = []byte(`podSpec:
       emptyDir: {}
   containers:
     - name: report-progress
-      image: quay.io/ocp-cert/openshift-tests-provider-cert:v0.2.1
+      image: quay.io/ocp-cert/openshift-tests-provider-cert:dev20230106125451
       imagePullPolicy: Always
       priorityClassName: system-node-critical
       command: ["./report-progress.sh"]
@@ -271,7 +271,7 @@ sonobuoy-config:
   skipCleanup: true
 spec:
   name: plugin
-  image: quay.io/ocp-cert/openshift-tests-provider-cert:v0.2.1
+  image: quay.io/ocp-cert/openshift-tests-provider-cert:dev20230106125451
   imagePullPolicy: Always
   priorityClassName: system-node-critical
   volumeMounts:
@@ -324,7 +324,7 @@ var _manifestsOpenshiftKubeConformanceYaml = []byte(`podSpec:
       emptyDir: {}
   containers:
     - name: report-progress
-      image: quay.io/ocp-cert/openshift-tests-provider-cert:v0.2.1
+      image: quay.io/ocp-cert/openshift-tests-provider-cert:dev20230106125451
       imagePullPolicy: Always
       priorityClassName: system-node-critical
       command: ["./report-progress.sh"]
@@ -357,7 +357,7 @@ sonobuoy-config:
   skipCleanup: true
 spec:
   name: plugin
-  image: quay.io/ocp-cert/openshift-tests-provider-cert:v0.2.1
+  image: quay.io/ocp-cert/openshift-tests-provider-cert:dev20230106125451
   imagePullPolicy: Always
   priorityClassName: system-node-critical
   volumeMounts:

--- a/pkg/assets/bindata.go
+++ b/pkg/assets/bindata.go
@@ -291,6 +291,11 @@ spec:
       valueFrom:
         fieldRef:
           fieldPath: metadata.namespace
+    - name: RUN_MODE
+      valueFrom:
+        configMapKeyRef:
+          name: plugins-config
+          key: run-mode
     - name: DEV_MODE_COUNT
       valueFrom:
         configMapKeyRef:
@@ -377,6 +382,11 @@ spec:
       valueFrom:
         fieldRef:
           fieldPath: metadata.namespace
+    - name: RUN_MODE
+      valueFrom:
+        configMapKeyRef:
+          name: plugins-config
+          key: run-mode
     - name: DEV_MODE_COUNT
       valueFrom:
         configMapKeyRef:

--- a/pkg/assets/bindata.go
+++ b/pkg/assets/bindata.go
@@ -64,7 +64,7 @@ var _manifestsOpenshiftArtifactsCollectorYaml = []byte(`podSpec:
       emptyDir: {}
   containers:
     - name: report-progress
-      image: quay.io/ocp-cert/openshift-tests-provider-cert:dev20230117180458
+      image: quay.io/ocp-cert/openshift-tests-provider-cert:v0.3.0-dev0
       imagePullPolicy: Always
       priorityClassName: system-node-critical
       command: ["./report-progress.sh"]
@@ -97,7 +97,7 @@ sonobuoy-config:
   skipCleanup: true
 spec:
   name: plugin
-  image: quay.io/ocp-cert/openshift-tests-provider-cert:dev20230117180458
+  image: quay.io/ocp-cert/openshift-tests-provider-cert:v0.3.0-dev0
   imagePullPolicy: Always
   volumeMounts:
   - mountPath: /tmp/sonobuoy/results
@@ -144,7 +144,7 @@ var _manifestsOpenshiftClusterUpgradeYaml = []byte(`podSpec:
       emptyDir: {}
   containers:
     - name: report-progress
-      image: quay.io/ocp-cert/openshift-tests-provider-cert:dev20230117180458
+      image: quay.io/ocp-cert/openshift-tests-provider-cert:v0.3.0-dev0
       imagePullPolicy: Always
       priorityClassName: system-node-critical
       command: ["./report-progress.sh"]
@@ -177,7 +177,7 @@ sonobuoy-config:
   skipCleanup: true
 spec:
   name: plugin
-  image: quay.io/ocp-cert/openshift-tests-provider-cert:dev20230117180458
+  image: quay.io/ocp-cert/openshift-tests-provider-cert:v0.3.0-dev0
   imagePullPolicy: Always
   priorityClassName: system-node-critical
   volumeMounts:
@@ -235,7 +235,7 @@ var _manifestsOpenshiftConformanceValidatedYaml = []byte(`podSpec:
       emptyDir: {}
   containers:
     - name: report-progress
-      image: quay.io/ocp-cert/openshift-tests-provider-cert:dev20230117180458
+      image: quay.io/ocp-cert/openshift-tests-provider-cert:v0.3.0-dev0
       imagePullPolicy: Always
       priorityClassName: system-node-critical
       command: ["./report-progress.sh"]
@@ -268,7 +268,7 @@ sonobuoy-config:
   skipCleanup: true
 spec:
   name: plugin
-  image: quay.io/ocp-cert/openshift-tests-provider-cert:dev20230117180458
+  image: quay.io/ocp-cert/openshift-tests-provider-cert:v0.3.0-dev0
   imagePullPolicy: Always
   priorityClassName: system-node-critical
   volumeMounts:
@@ -316,7 +316,7 @@ var _manifestsOpenshiftKubeConformanceYaml = []byte(`podSpec:
       emptyDir: {}
   containers:
     - name: report-progress
-      image: quay.io/ocp-cert/openshift-tests-provider-cert:dev20230117180458
+      image: quay.io/ocp-cert/openshift-tests-provider-cert:v0.3.0-dev0
       imagePullPolicy: Always
       priorityClassName: system-node-critical
       command: ["./report-progress.sh"]
@@ -349,7 +349,7 @@ sonobuoy-config:
   skipCleanup: true
 spec:
   name: plugin
-  image: quay.io/ocp-cert/openshift-tests-provider-cert:dev20230117180458
+  image: quay.io/ocp-cert/openshift-tests-provider-cert:v0.3.0-dev0
   imagePullPolicy: Always
   priorityClassName: system-node-critical
   volumeMounts:

--- a/pkg/assets/bindata.go
+++ b/pkg/assets/bindata.go
@@ -64,7 +64,7 @@ var _manifestsOpenshiftArtifactsCollectorYaml = []byte(`podSpec:
       emptyDir: {}
   containers:
     - name: report-progress
-      image: quay.io/ocp-cert/openshift-tests-provider-cert:dev20230124170906
+      image: quay.io/ocp-cert/openshift-tests-provider-cert:v0.3.0-alpha0
       imagePullPolicy: Always
       priorityClassName: system-node-critical
       command: ["./report-progress.sh"]
@@ -97,7 +97,7 @@ sonobuoy-config:
   skipCleanup: true
 spec:
   name: plugin
-  image: quay.io/ocp-cert/openshift-tests-provider-cert:dev20230124170906
+  image: quay.io/ocp-cert/openshift-tests-provider-cert:v0.3.0-alpha0
   imagePullPolicy: Always
   volumeMounts:
   - mountPath: /tmp/sonobuoy/results
@@ -149,7 +149,7 @@ var _manifestsOpenshiftClusterUpgradeYaml = []byte(`podSpec:
       emptyDir: {}
   containers:
     - name: report-progress
-      image: quay.io/ocp-cert/openshift-tests-provider-cert:dev20230124170906
+      image: quay.io/ocp-cert/openshift-tests-provider-cert:v0.3.0-alpha0
       imagePullPolicy: Always
       priorityClassName: system-node-critical
       command: ["./report-progress.sh"]
@@ -182,7 +182,7 @@ sonobuoy-config:
   skipCleanup: true
 spec:
   name: plugin
-  image: quay.io/ocp-cert/openshift-tests-provider-cert:dev20230124170906
+  image: quay.io/ocp-cert/openshift-tests-provider-cert:v0.3.0-alpha0
   imagePullPolicy: Always
   priorityClassName: system-node-critical
   volumeMounts:
@@ -240,7 +240,7 @@ var _manifestsOpenshiftConformanceValidatedYaml = []byte(`podSpec:
       emptyDir: {}
   containers:
     - name: report-progress
-      image: quay.io/ocp-cert/openshift-tests-provider-cert:dev20230124170906
+      image: quay.io/ocp-cert/openshift-tests-provider-cert:v0.3.0-alpha0
       imagePullPolicy: Always
       priorityClassName: system-node-critical
       command: ["./report-progress.sh"]
@@ -273,7 +273,7 @@ sonobuoy-config:
   skipCleanup: true
 spec:
   name: plugin
-  image: quay.io/ocp-cert/openshift-tests-provider-cert:dev20230124170906
+  image: quay.io/ocp-cert/openshift-tests-provider-cert:v0.3.0-alpha0
   imagePullPolicy: Always
   priorityClassName: system-node-critical
   volumeMounts:
@@ -331,7 +331,7 @@ var _manifestsOpenshiftKubeConformanceYaml = []byte(`podSpec:
       emptyDir: {}
   containers:
     - name: report-progress
-      image: quay.io/ocp-cert/openshift-tests-provider-cert:dev20230124170906
+      image: quay.io/ocp-cert/openshift-tests-provider-cert:v0.3.0-alpha0
       imagePullPolicy: Always
       priorityClassName: system-node-critical
       command: ["./report-progress.sh"]
@@ -364,7 +364,7 @@ sonobuoy-config:
   skipCleanup: true
 spec:
   name: plugin
-  image: quay.io/ocp-cert/openshift-tests-provider-cert:dev20230124170906
+  image: quay.io/ocp-cert/openshift-tests-provider-cert:v0.3.0-alpha0
   imagePullPolicy: Always
   priorityClassName: system-node-critical
   volumeMounts:

--- a/pkg/assets/bindata.go
+++ b/pkg/assets/bindata.go
@@ -64,7 +64,7 @@ var _manifestsOpenshiftArtifactsCollectorYaml = []byte(`podSpec:
       emptyDir: {}
   containers:
     - name: report-progress
-      image: quay.io/ocp-cert/openshift-tests-provider-cert:dev20230124153456
+      image: quay.io/ocp-cert/openshift-tests-provider-cert:dev20230124170906
       imagePullPolicy: Always
       priorityClassName: system-node-critical
       command: ["./report-progress.sh"]
@@ -97,7 +97,7 @@ sonobuoy-config:
   skipCleanup: true
 spec:
   name: plugin
-  image: quay.io/ocp-cert/openshift-tests-provider-cert:dev20230124153456
+  image: quay.io/ocp-cert/openshift-tests-provider-cert:dev20230124170906
   imagePullPolicy: Always
   volumeMounts:
   - mountPath: /tmp/sonobuoy/results
@@ -119,6 +119,11 @@ spec:
       valueFrom:
         fieldRef:
           fieldPath: metadata.namespace
+    - name: RUN_MODE
+      valueFrom:
+        configMapKeyRef:
+          name: plugins-config
+          key: run-mode
 `)
 
 func manifestsOpenshiftArtifactsCollectorYamlBytes() ([]byte, error) {
@@ -144,7 +149,7 @@ var _manifestsOpenshiftClusterUpgradeYaml = []byte(`podSpec:
       emptyDir: {}
   containers:
     - name: report-progress
-      image: quay.io/ocp-cert/openshift-tests-provider-cert:dev20230124153456
+      image: quay.io/ocp-cert/openshift-tests-provider-cert:dev20230124170906
       imagePullPolicy: Always
       priorityClassName: system-node-critical
       command: ["./report-progress.sh"]
@@ -177,7 +182,7 @@ sonobuoy-config:
   skipCleanup: true
 spec:
   name: plugin
-  image: quay.io/ocp-cert/openshift-tests-provider-cert:dev20230124153456
+  image: quay.io/ocp-cert/openshift-tests-provider-cert:dev20230124170906
   imagePullPolicy: Always
   priorityClassName: system-node-critical
   volumeMounts:
@@ -235,7 +240,7 @@ var _manifestsOpenshiftConformanceValidatedYaml = []byte(`podSpec:
       emptyDir: {}
   containers:
     - name: report-progress
-      image: quay.io/ocp-cert/openshift-tests-provider-cert:dev20230124153456
+      image: quay.io/ocp-cert/openshift-tests-provider-cert:dev20230124170906
       imagePullPolicy: Always
       priorityClassName: system-node-critical
       command: ["./report-progress.sh"]
@@ -268,7 +273,7 @@ sonobuoy-config:
   skipCleanup: true
 spec:
   name: plugin
-  image: quay.io/ocp-cert/openshift-tests-provider-cert:dev20230124153456
+  image: quay.io/ocp-cert/openshift-tests-provider-cert:dev20230124170906
   imagePullPolicy: Always
   priorityClassName: system-node-critical
   volumeMounts:
@@ -326,7 +331,7 @@ var _manifestsOpenshiftKubeConformanceYaml = []byte(`podSpec:
       emptyDir: {}
   containers:
     - name: report-progress
-      image: quay.io/ocp-cert/openshift-tests-provider-cert:dev20230124153456
+      image: quay.io/ocp-cert/openshift-tests-provider-cert:dev20230124170906
       imagePullPolicy: Always
       priorityClassName: system-node-critical
       command: ["./report-progress.sh"]
@@ -359,7 +364,7 @@ sonobuoy-config:
   skipCleanup: true
 spec:
   name: plugin
-  image: quay.io/ocp-cert/openshift-tests-provider-cert:dev20230124153456
+  image: quay.io/ocp-cert/openshift-tests-provider-cert:dev20230124170906
   imagePullPolicy: Always
   priorityClassName: system-node-critical
   volumeMounts:

--- a/pkg/assets/bindata.go
+++ b/pkg/assets/bindata.go
@@ -64,14 +64,10 @@ var _manifestsOpenshiftArtifactsCollectorYaml = []byte(`podSpec:
       emptyDir: {}
   containers:
     - name: report-progress
-      image: quay.io/ocp-cert/openshift-tests-provider-cert:dev20230117175707
+      image: quay.io/ocp-cert/openshift-tests-provider-cert:dev20230117180458
       imagePullPolicy: Always
       priorityClassName: system-node-critical
       command: ["./report-progress.sh"]
-      # securityContext:
-      #   privileged: true
-      #   allowPrivilegeEscalation: true
-      #   readOnlyRootFilesystem: false
       volumeMounts:
       - mountPath: /tmp/sonobuoy/results
         name: results
@@ -101,13 +97,8 @@ sonobuoy-config:
   skipCleanup: true
 spec:
   name: plugin
-  image: quay.io/ocp-cert/openshift-tests-provider-cert:dev20230117175707
+  image: quay.io/ocp-cert/openshift-tests-provider-cert:dev20230117180458
   imagePullPolicy: Always
-  #priorityClassName: system-node-critical
-  # securityContext:
-  #   privileged: true
-  #   allowPrivilegeEscalation: true
-  #   readOnlyRootFilesystem: false
   volumeMounts:
   - mountPath: /tmp/sonobuoy/results
     name: results
@@ -153,14 +144,10 @@ var _manifestsOpenshiftClusterUpgradeYaml = []byte(`podSpec:
       emptyDir: {}
   containers:
     - name: report-progress
-      image: quay.io/ocp-cert/openshift-tests-provider-cert:dev20230117175707
+      image: quay.io/ocp-cert/openshift-tests-provider-cert:dev20230117180458
       imagePullPolicy: Always
       priorityClassName: system-node-critical
       command: ["./report-progress.sh"]
-      # securityContext:
-      #   privileged: true
-      #   allowPrivilegeEscalation: true
-      #   readOnlyRootFilesystem: false
       volumeMounts:
       - mountPath: /tmp/sonobuoy/results
         name: results
@@ -190,13 +177,9 @@ sonobuoy-config:
   skipCleanup: true
 spec:
   name: plugin
-  image: quay.io/ocp-cert/openshift-tests-provider-cert:dev20230117175707
+  image: quay.io/ocp-cert/openshift-tests-provider-cert:dev20230117180458
   imagePullPolicy: Always
   priorityClassName: system-node-critical
-  # securityContext:
-  #   privileged: true
-  #   allowPrivilegeEscalation: true
-  #   readOnlyRootFilesystem: false
   volumeMounts:
   - mountPath: /tmp/sonobuoy/results
     name: results
@@ -252,14 +235,10 @@ var _manifestsOpenshiftConformanceValidatedYaml = []byte(`podSpec:
       emptyDir: {}
   containers:
     - name: report-progress
-      image: quay.io/ocp-cert/openshift-tests-provider-cert:dev20230117175707
+      image: quay.io/ocp-cert/openshift-tests-provider-cert:dev20230117180458
       imagePullPolicy: Always
       priorityClassName: system-node-critical
       command: ["./report-progress.sh"]
-      # securityContext:
-      #   privileged: true
-      #   allowPrivilegeEscalation: true
-      #   readOnlyRootFilesystem: false
       volumeMounts:
       - mountPath: /tmp/sonobuoy/results
         name: results
@@ -289,13 +268,9 @@ sonobuoy-config:
   skipCleanup: true
 spec:
   name: plugin
-  image: quay.io/ocp-cert/openshift-tests-provider-cert:dev20230117175707
+  image: quay.io/ocp-cert/openshift-tests-provider-cert:dev20230117180458
   imagePullPolicy: Always
   priorityClassName: system-node-critical
-  # securityContext:
-  #   privileged: true
-  #   allowPrivilegeEscalation: true
-  #   readOnlyRootFilesystem: false
   volumeMounts:
   - mountPath: /tmp/sonobuoy/results
     name: results
@@ -316,11 +291,6 @@ spec:
       valueFrom:
         fieldRef:
           fieldPath: metadata.namespace
-    - name: DEV_MODE_COUNT
-      valueFrom:
-        configMapKeyRef:
-          name: plugins-config
-          key: dev-count
 `)
 
 func manifestsOpenshiftConformanceValidatedYamlBytes() ([]byte, error) {
@@ -346,14 +316,10 @@ var _manifestsOpenshiftKubeConformanceYaml = []byte(`podSpec:
       emptyDir: {}
   containers:
     - name: report-progress
-      image: quay.io/ocp-cert/openshift-tests-provider-cert:dev20230117175707
+      image: quay.io/ocp-cert/openshift-tests-provider-cert:dev20230117180458
       imagePullPolicy: Always
       priorityClassName: system-node-critical
       command: ["./report-progress.sh"]
-      # securityContext:
-      #   privileged: true
-      #   allowPrivilegeEscalation: true
-      #   readOnlyRootFilesystem: false
       volumeMounts:
       - mountPath: /tmp/sonobuoy/results
         name: results
@@ -383,13 +349,9 @@ sonobuoy-config:
   skipCleanup: true
 spec:
   name: plugin
-  image: quay.io/ocp-cert/openshift-tests-provider-cert:dev20230117175707
+  image: quay.io/ocp-cert/openshift-tests-provider-cert:dev20230117180458
   imagePullPolicy: Always
   priorityClassName: system-node-critical
-  # securityContext:
-  #   privileged: true
-  #   allowPrivilegeEscalation: true
-  #   readOnlyRootFilesystem: false
   volumeMounts:
   - mountPath: /tmp/sonobuoy/results
     name: results
@@ -410,11 +372,6 @@ spec:
       valueFrom:
         fieldRef:
           fieldPath: metadata.namespace
-    - name: DEV_MODE_COUNT
-      valueFrom:
-        configMapKeyRef:
-          name: plugins-config
-          key: dev-count
 `)
 
 func manifestsOpenshiftKubeConformanceYamlBytes() ([]byte, error) {

--- a/pkg/assets/bindata.go
+++ b/pkg/assets/bindata.go
@@ -64,10 +64,14 @@ var _manifestsOpenshiftArtifactsCollectorYaml = []byte(`podSpec:
       emptyDir: {}
   containers:
     - name: report-progress
-      image: quay.io/ocp-cert/openshift-tests-provider-cert:dev20230109124258
+      image: quay.io/ocp-cert/openshift-tests-provider-cert:dev20230117175707
       imagePullPolicy: Always
       priorityClassName: system-node-critical
       command: ["./report-progress.sh"]
+      # securityContext:
+      #   privileged: true
+      #   allowPrivilegeEscalation: true
+      #   readOnlyRootFilesystem: false
       volumeMounts:
       - mountPath: /tmp/sonobuoy/results
         name: results
@@ -97,9 +101,13 @@ sonobuoy-config:
   skipCleanup: true
 spec:
   name: plugin
-  image: quay.io/ocp-cert/openshift-tests-provider-cert:dev20230109124258
+  image: quay.io/ocp-cert/openshift-tests-provider-cert:dev20230117175707
   imagePullPolicy: Always
-  priorityClassName: system-node-critical
+  #priorityClassName: system-node-critical
+  # securityContext:
+  #   privileged: true
+  #   allowPrivilegeEscalation: true
+  #   readOnlyRootFilesystem: false
   volumeMounts:
   - mountPath: /tmp/sonobuoy/results
     name: results
@@ -145,10 +153,14 @@ var _manifestsOpenshiftClusterUpgradeYaml = []byte(`podSpec:
       emptyDir: {}
   containers:
     - name: report-progress
-      image: quay.io/ocp-cert/openshift-tests-provider-cert:dev20230109124258
+      image: quay.io/ocp-cert/openshift-tests-provider-cert:dev20230117175707
       imagePullPolicy: Always
       priorityClassName: system-node-critical
       command: ["./report-progress.sh"]
+      # securityContext:
+      #   privileged: true
+      #   allowPrivilegeEscalation: true
+      #   readOnlyRootFilesystem: false
       volumeMounts:
       - mountPath: /tmp/sonobuoy/results
         name: results
@@ -178,9 +190,13 @@ sonobuoy-config:
   skipCleanup: true
 spec:
   name: plugin
-  image: quay.io/ocp-cert/openshift-tests-provider-cert:dev20230109124258
+  image: quay.io/ocp-cert/openshift-tests-provider-cert:dev20230117175707
   imagePullPolicy: Always
   priorityClassName: system-node-critical
+  # securityContext:
+  #   privileged: true
+  #   allowPrivilegeEscalation: true
+  #   readOnlyRootFilesystem: false
   volumeMounts:
   - mountPath: /tmp/sonobuoy/results
     name: results
@@ -201,8 +217,6 @@ spec:
       valueFrom:
         fieldRef:
           fieldPath: metadata.namespace
-    - name: RUN_MODE
-      value: upgrade
     - name: UPGRADE_RELEASES
       valueFrom:
         configMapKeyRef:
@@ -238,10 +252,14 @@ var _manifestsOpenshiftConformanceValidatedYaml = []byte(`podSpec:
       emptyDir: {}
   containers:
     - name: report-progress
-      image: quay.io/ocp-cert/openshift-tests-provider-cert:dev20230109124258
+      image: quay.io/ocp-cert/openshift-tests-provider-cert:dev20230117175707
       imagePullPolicy: Always
       priorityClassName: system-node-critical
       command: ["./report-progress.sh"]
+      # securityContext:
+      #   privileged: true
+      #   allowPrivilegeEscalation: true
+      #   readOnlyRootFilesystem: false
       volumeMounts:
       - mountPath: /tmp/sonobuoy/results
         name: results
@@ -271,9 +289,13 @@ sonobuoy-config:
   skipCleanup: true
 spec:
   name: plugin
-  image: quay.io/ocp-cert/openshift-tests-provider-cert:dev20230109124258
+  image: quay.io/ocp-cert/openshift-tests-provider-cert:dev20230117175707
   imagePullPolicy: Always
   priorityClassName: system-node-critical
+  # securityContext:
+  #   privileged: true
+  #   allowPrivilegeEscalation: true
+  #   readOnlyRootFilesystem: false
   volumeMounts:
   - mountPath: /tmp/sonobuoy/results
     name: results
@@ -324,10 +346,14 @@ var _manifestsOpenshiftKubeConformanceYaml = []byte(`podSpec:
       emptyDir: {}
   containers:
     - name: report-progress
-      image: quay.io/ocp-cert/openshift-tests-provider-cert:dev20230109124258
+      image: quay.io/ocp-cert/openshift-tests-provider-cert:dev20230117175707
       imagePullPolicy: Always
       priorityClassName: system-node-critical
       command: ["./report-progress.sh"]
+      # securityContext:
+      #   privileged: true
+      #   allowPrivilegeEscalation: true
+      #   readOnlyRootFilesystem: false
       volumeMounts:
       - mountPath: /tmp/sonobuoy/results
         name: results
@@ -357,9 +383,13 @@ sonobuoy-config:
   skipCleanup: true
 spec:
   name: plugin
-  image: quay.io/ocp-cert/openshift-tests-provider-cert:dev20230109124258
+  image: quay.io/ocp-cert/openshift-tests-provider-cert:dev20230117175707
   imagePullPolicy: Always
   priorityClassName: system-node-critical
+  # securityContext:
+  #   privileged: true
+  #   allowPrivilegeEscalation: true
+  #   readOnlyRootFilesystem: false
   volumeMounts:
   - mountPath: /tmp/sonobuoy/results
     name: results

--- a/pkg/assets/bindata.go
+++ b/pkg/assets/bindata.go
@@ -64,7 +64,7 @@ var _manifestsOpenshiftArtifactsCollectorYaml = []byte(`podSpec:
       emptyDir: {}
   containers:
     - name: report-progress
-      image: quay.io/ocp-cert/openshift-tests-provider-cert:v0.3.0-dev0
+      image: quay.io/ocp-cert/openshift-tests-provider-cert:dev20230124153456
       imagePullPolicy: Always
       priorityClassName: system-node-critical
       command: ["./report-progress.sh"]
@@ -97,7 +97,7 @@ sonobuoy-config:
   skipCleanup: true
 spec:
   name: plugin
-  image: quay.io/ocp-cert/openshift-tests-provider-cert:v0.3.0-dev0
+  image: quay.io/ocp-cert/openshift-tests-provider-cert:dev20230124153456
   imagePullPolicy: Always
   volumeMounts:
   - mountPath: /tmp/sonobuoy/results
@@ -144,7 +144,7 @@ var _manifestsOpenshiftClusterUpgradeYaml = []byte(`podSpec:
       emptyDir: {}
   containers:
     - name: report-progress
-      image: quay.io/ocp-cert/openshift-tests-provider-cert:v0.3.0-dev0
+      image: quay.io/ocp-cert/openshift-tests-provider-cert:dev20230124153456
       imagePullPolicy: Always
       priorityClassName: system-node-critical
       command: ["./report-progress.sh"]
@@ -177,7 +177,7 @@ sonobuoy-config:
   skipCleanup: true
 spec:
   name: plugin
-  image: quay.io/ocp-cert/openshift-tests-provider-cert:v0.3.0-dev0
+  image: quay.io/ocp-cert/openshift-tests-provider-cert:dev20230124153456
   imagePullPolicy: Always
   priorityClassName: system-node-critical
   volumeMounts:
@@ -235,7 +235,7 @@ var _manifestsOpenshiftConformanceValidatedYaml = []byte(`podSpec:
       emptyDir: {}
   containers:
     - name: report-progress
-      image: quay.io/ocp-cert/openshift-tests-provider-cert:v0.3.0-dev0
+      image: quay.io/ocp-cert/openshift-tests-provider-cert:dev20230124153456
       imagePullPolicy: Always
       priorityClassName: system-node-critical
       command: ["./report-progress.sh"]
@@ -268,7 +268,7 @@ sonobuoy-config:
   skipCleanup: true
 spec:
   name: plugin
-  image: quay.io/ocp-cert/openshift-tests-provider-cert:v0.3.0-dev0
+  image: quay.io/ocp-cert/openshift-tests-provider-cert:dev20230124153456
   imagePullPolicy: Always
   priorityClassName: system-node-critical
   volumeMounts:
@@ -326,7 +326,7 @@ var _manifestsOpenshiftKubeConformanceYaml = []byte(`podSpec:
       emptyDir: {}
   containers:
     - name: report-progress
-      image: quay.io/ocp-cert/openshift-tests-provider-cert:v0.3.0-dev0
+      image: quay.io/ocp-cert/openshift-tests-provider-cert:dev20230124153456
       imagePullPolicy: Always
       priorityClassName: system-node-critical
       command: ["./report-progress.sh"]
@@ -359,7 +359,7 @@ sonobuoy-config:
   skipCleanup: true
 spec:
   name: plugin
-  image: quay.io/ocp-cert/openshift-tests-provider-cert:v0.3.0-dev0
+  image: quay.io/ocp-cert/openshift-tests-provider-cert:dev20230124153456
   imagePullPolicy: Always
   priorityClassName: system-node-critical
   volumeMounts:

--- a/pkg/assets/bindata.go
+++ b/pkg/assets/bindata.go
@@ -171,7 +171,7 @@ var _manifestsOpenshiftClusterUpgradeYaml = []byte(`podSpec:
               fieldPath: metadata.namespace
 sonobuoy-config:
   driver: Job
-  plugin-name: 01-openshift-cluster-upgrade
+  plugin-name: 05-openshift-cluster-upgrade
   result-format: junit
   description: The end-to-end tests maintained by OpenShift to certify the Provider running the OpenShift Container Platform.
   source-url: https://github.com/redhat-openshift-ecosystem/provider-certification-tool/blob/main/manifests/openshift-conformance-validated.yaml
@@ -207,7 +207,7 @@ spec:
       valueFrom:
         configMapKeyRef:
           name: plugins-config
-          key: upgrade-target-image
+          key: upgrade-target-images
     - name: RUN_MODE
       valueFrom:
         configMapKeyRef:

--- a/pkg/run/run.go
+++ b/pkg/run/run.go
@@ -44,7 +44,11 @@ type RunOptions struct {
 	upgradeImage  string
 }
 
-const runTimeoutSeconds = 21600
+const (
+	runTimeoutSeconds      = 21600
+	dedicatedLabelKey      = "node-role.kubernetes.io/tests"
+	dedicatedLabelKeyValue = "node-role.kubernetes.io/tests="
+)
 
 func newRunOptions() *RunOptions {
 	return &RunOptions{
@@ -136,7 +140,7 @@ func NewCmdRun() *cobra.Command {
 // PreRunCheck performs some checks before kicking off Sonobuoy
 func (r *RunOptions) PreRunCheck(kclient kubernetes.Interface) error {
 	coreClient := kclient.CoreV1()
-	// rbacClient := kclient.RbacV1()
+	rbacClient := kclient.RbacV1()
 
 	// Get ConfigV1 client for Cluster Operators
 	restConfig, err := client.CreateRestConfig()
@@ -426,7 +430,7 @@ func (r *RunOptions) Run(kclient kubernetes.Interface, sclient sonobuoyclient.In
 			EnableRBAC:         false, // RBAC is created in preflight
 			ImagePullPolicy:    config.DefaultSonobuoyPullPolicy,
 			StaticPlugins:      manifests,
-			PluginEnvOverrides: nil, // TODO We'll use this later
+			PluginEnvOverrides: nil,
 		},
 	}
 

--- a/pkg/run/run.go
+++ b/pkg/run/run.go
@@ -132,7 +132,6 @@ func NewCmdRun() *cobra.Command {
 
 	// Hide dedicated flag since this is for development only
 	cmd.Flags().MarkHidden("dedicated")
-	cmd.Flags().MarkHidden("dev-count")
 
 	return cmd
 }

--- a/pkg/run/run.go
+++ b/pkg/run/run.go
@@ -136,7 +136,7 @@ func NewCmdRun() *cobra.Command {
 // PreRunCheck performs some checks before kicking off Sonobuoy
 func (r *RunOptions) PreRunCheck(kclient kubernetes.Interface) error {
 	coreClient := kclient.CoreV1()
-	rbacClient := kclient.RbacV1()
+	// rbacClient := kclient.RbacV1()
 
 	// Get ConfigV1 client for Cluster Operators
 	restConfig, err := client.CreateRestConfig()

--- a/pkg/run/run.go
+++ b/pkg/run/run.go
@@ -181,6 +181,7 @@ func (r *RunOptions) PreRunCheck(kclient kubernetes.Interface) error {
 	// TODO: checkOrCreate MachineConfigPool with:
 	// - node selectors: node-role.kubernetes.io/tests=''
 	// - paused: true
+	// https://issues.redhat.com/browse/OPCT-35
 
 	// Check if sonobuoy namespace already exists
 	p, err := coreClient.Namespaces().Get(context.TODO(), pkg.CertificationNamespace, metav1.GetOptions{})

--- a/pkg/run/run.go
+++ b/pkg/run/run.go
@@ -42,7 +42,6 @@ type RunOptions struct {
 	devCount      string
 	mode          string
 	upgradeImage  string
-	devCount      string
 }
 
 const (
@@ -132,7 +131,6 @@ func NewCmdRun() *cobra.Command {
 	cmd.Flags().StringVar(&o.sonobuoyImage, "sonobuoy-image", fmt.Sprintf("quay.io/ocp-cert/sonobuoy:%s", buildinfo.Version), "Image override for the Sonobuoy worker and aggregator")
 	cmd.Flags().IntVar(&o.timeout, "timeout", defaultRunTimeoutSeconds, "Execution timeout in seconds")
 	cmd.Flags().BoolVarP(&o.watch, "watch", "w", defaultRunWatchFlag, "Keep watch status after running")
-	cmd.Flags().StringVar(&o.devCount, "dev-count", "0", "Developer Mode only: run small random set of tests. Default: 0 (disabled)")
 
 	// Hide dedicated flag since this is for development only
 	cmd.Flags().MarkHidden("dedicated")
@@ -180,10 +178,9 @@ func (r *RunOptions) PreRunCheck(kclient kubernetes.Interface) error {
 		return errors.New("OpenShift Image Registry must deployed before certification can run")
 	}
 
-	// // Check if MachineConfigPool exists and create
-	// if err := checkCreateMCP(irClient); err != nil {
-	// 	return errors.Wrap(err, "error creating MachineConfigPool")
-	// }
+	// TODO: checkOrCreate MachineConfigPool with:
+	// - node selectors: node-role.kubernetes.io/tests=''
+	// - paused: true
 
 	// Check if sonobuoy namespace already exists
 	p, err := coreClient.Namespaces().Get(context.TODO(), pkg.CertificationNamespace, metav1.GetOptions{})
@@ -383,7 +380,6 @@ func (r *RunOptions) Run(kclient kubernetes.Interface, sclient sonobuoyclient.In
 			"dev-count":             r.devCount,
 			"run-mode":              r.mode,
 			"upgrade-target-images": r.upgradeImage,
-			"dev-count":             r.devCount,
 		},
 	}); err != nil {
 		return err
@@ -492,17 +488,3 @@ func checkRegistry(irClient irclient.Interface) (bool, error) {
 
 	return true, nil
 }
-
-// // Check or create MachineConfigPool
-// func checkCreateMCP(mcpClient mcpclient.Interface) (bool, error) {
-// 	irConfig, err := mcpclient.ImageregistryV1().Configs().Get(context.TODO(), "cluster", metav1.GetOptions{})
-// 	if err != nil {
-// 		return false, err
-// 	}
-
-// 	if irConfig.Spec.ManagementState != operatorv1.Managed {
-// 		return false, nil
-// 	}
-
-// 	return true, nil
-// }


### PR DESCRIPTION
https://issues.redhat.com/browse/SPLAT-651

Support upgrade conformance.
- Introduces new flags to control whether the execution needs to run the upgrade cluster or not:
  - `--mode=upgrade`
  - `--upgrade-to-image=<release_digest>` (`$(oc adm release info 4.Y+1.Z -o jsonpath={.image}`)
- Create config map with plugin variables (the sonobuoy native feature wipes all existing from `podSpec` which is undesired)
- add a new plugin instance of openshift-tests to run upgrades: `05-openshift-cluster-upgrade`

Blocked by:
- [x] https://github.com/redhat-openshift-ecosystem/provider-certification-tool/pull/31
- [x]  https://github.com/redhat-openshift-ecosystem/provider-certification-tool/pull/34

Blocked by Plugin release:

- [x] https://github.com/redhat-openshift-ecosystem/provider-certification-plugins/pull/24

Checklist:
- [x] CLI changes to run in upgrade mode
- [x] CLI changes to get the release image digest
- [x] Plugin implementation: https://github.com/redhat-openshift-ecosystem/provider-certification-plugins/pull/24
- [x] Validate y-stream upgrades
- [x] Fix RBAC #34 for Cluster upgrade
- [x] Fix SecurityContextMode for Sonobuoy aggregator stuck on 4.10->4.11 #39 
- [x] MachineConfigPool validation: 'opct' object is validated if present when running `mode=upgrade` on the runtime (plugin execution). Failures will be raised by the plugin when the MCP is not present (the User Docs should keep it very explicit): Tests described here: https://github.com/redhat-openshift-ecosystem/provider-certification-plugins/pull/24#issuecomment-1402907134
- [x] User Documentation

Tests checklist:
- [x] upgrade 4.12-> 4.13