### PR TITLE
OPCT-6 - fix/rbac: manage custom ServiceAccount and roles

### DIFF
--- a/pkg/destroy/destroy.go
+++ b/pkg/destroy/destroy.go
@@ -112,11 +112,11 @@ func (d *DestroyOptions) DeleteTestNamespaces(kclient kubernetes.Interface) erro
 func (d *DestroyOptions) RestoreSCC(kclient kubernetes.Interface) error {
 	client := kclient.RbacV1()
 
-	err := client.ClusterRoleBindings().Delete(context.TODO(), pkg.AnyUIDClusterRoleBinding, metav1.DeleteOptions{})
+	err := client.ClusterRoles().Delete(context.TODO(), pkg.PrivilegedClusterRole, metav1.DeleteOptions{})
 	if err != nil {
 		return err
 	}
-	log.Infof("Deleted %s ClusterRoleBinding", pkg.AnyUIDClusterRoleBinding)
+	log.Infof("Deleted %s ClusterRole", pkg.PrivilegedClusterRole)
 
 	err = client.ClusterRoleBindings().Delete(context.TODO(), pkg.PrivilegedClusterRoleBinding, metav1.DeleteOptions{})
 	if err != nil {

--- a/pkg/run/run.go
+++ b/pkg/run/run.go
@@ -2,6 +2,7 @@ package run
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"time"
 
@@ -22,7 +23,7 @@ import (
 	rbacv1 "k8s.io/api/rbac/v1"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/util/json"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/kubernetes"
 
 	"github.com/redhat-openshift-ecosystem/provider-certification-tool/pkg"
@@ -127,7 +128,6 @@ func NewCmdRun() *cobra.Command {
 
 // PreRunCheck performs some checks before kicking off Sonobuoy
 func (r *RunOptions) PreRunCheck(kclient kubernetes.Interface) error {
-	var namespace *v1.Namespace
 	coreClient := kclient.CoreV1()
 	rbacClient := kclient.RbacV1()
 
@@ -179,6 +179,13 @@ func (r *RunOptions) PreRunCheck(kclient kubernetes.Interface) error {
 		return errors.New(fmt.Sprintf("%s namespace already exists", pkg.CertificationNamespace))
 	}
 
+	namespace := &v1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   pkg.CertificationNamespace,
+			Labels: pkg.SonobuoyDefaultLabels,
+		},
+	}
+
 	if r.dedicated {
 
 		log.Info("Ensuring proper node label for dedicated mode")
@@ -192,7 +199,6 @@ func (r *RunOptions) PreRunCheck(kclient kubernetes.Interface) error {
 			return errors.New("No nodes with role required for dedicated mode (node-role.kubernetes.io/tests)")
 		}
 
-		// Skip preflight checks and create namespace manually with Tolerations
 		tolerations, err := json.Marshal([]v1.Toleration{{
 			Key:      pkg.DedicatedNodeRoleLabel,
 			Operator: v1.TolerationOpExists,
@@ -203,88 +209,95 @@ func (r *RunOptions) PreRunCheck(kclient kubernetes.Interface) error {
 			return err
 		}
 
-		namespace = &v1.Namespace{
-			ObjectMeta: metav1.ObjectMeta{
-				Name: pkg.CertificationNamespace,
-				Annotations: map[string]string{
-					"scheduler.alpha.kubernetes.io/defaultTolerations": string(tolerations),
-					"openshift.io/node-selector":                       pkg.DedicatedNodeRoleLabelSelector,
-				},
-			},
-		}
-	} else {
-		namespace = &v1.Namespace{
-			ObjectMeta: metav1.ObjectMeta{
-				Name: pkg.CertificationNamespace,
-			},
+		namespace.Annotations = map[string]string{
+			"scheduler.alpha.kubernetes.io/defaultTolerations": string(tolerations),
+			"openshift.io/node-selector":                       pkg.DedicatedNodeRoleLabelSelector,
 		}
 	}
 
 	_, err = kclient.CoreV1().Namespaces().Create(context.TODO(), namespace, metav1.CreateOptions{})
 	if err != nil {
-		return err
+		return errors.Wrap(err, "error creating Namespace")
 	}
 
 	// Create Sonobuoy ServiceAccount
-	serviceAccount := &v1.ServiceAccount{
+	// https://github.com/vmware-tanzu/sonobuoy/blob/main/pkg/client/gen.go#L611-L616
+	sa := &v1.ServiceAccount{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      pkg.SonobuoyServiceAccountName,
 			Namespace: pkg.CertificationNamespace,
-			Labels: map[string]string{
-				"component": pkg.SonobuoyComponentLabelValue,
-			},
+			Labels:    pkg.SonobuoyDefaultLabels,
 		},
 	}
-	_, err = kclient.CoreV1().ServiceAccounts(pkg.CertificationNamespace).Create(context.TODO(), serviceAccount, metav1.CreateOptions{})
+	sa.SetGroupVersionKind(schema.GroupVersionKind{Group: "", Version: "v1", Kind: "ServiceAccount"})
+
+	_, err = kclient.CoreV1().ServiceAccounts(pkg.CertificationNamespace).Create(context.TODO(), sa, metav1.CreateOptions{})
 	if err != nil {
-		return err
+		return errors.Wrap(err, "error creating ServiceAccount")
 	}
+
 	log.Info("Ensuring the tool will run in the privileged environment...")
 
-	// Configure SCC
-	anyuid := &rbacv1.ClusterRoleBinding{
+	// Configure custom RBAC
+
+	// Replacing Sonobuoy's default Admin RBAC not working correctly on upgrades.
+	// https://github.com/vmware-tanzu/sonobuoy/blob/5b97033257d0276c7b0d1b20412667a69d79261e/pkg/client/gen.go#L445-L481
+	cr := &rbacv1.ClusterRole{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: "system:openshift:scc:anyuid",
+			Name:      pkg.PrivilegedClusterRole,
+			Namespace: pkg.CertificationNamespace,
+			Labels:    pkg.SonobuoyDefaultLabels,
 		},
-		Subjects: []rbacv1.Subject{
+		Rules: []rbacv1.PolicyRule{
 			{
-				Kind:     rbacv1.ServiceAccountKind,
-				APIGroup: rbacv1.GroupName,
-				Name:     pkg.SonobuoyServiceAccountName,
+				APIGroups: []string{"*"},
+				Resources: []string{"*"},
+				Verbs:     []string{"*"},
+			},
+			{
+				NonResourceURLs: []string{"/metrics", "/logs", "/logs/*"},
+				Verbs:           []string{"get"},
 			},
 		},
-		RoleRef: rbacv1.RoleRef{
-			APIGroup: rbacv1.GroupName,
-			Kind:     "ClusterRole",
-			Name:     "system:openshift:scc:anyuid",
-		},
 	}
+	cr.SetGroupVersionKind(schema.GroupVersionKind{
+		Group:   rbacv1.GroupName,
+		Version: "v1",
+		Kind:    "ClusterRole",
+	})
 
-	privileged := &rbacv1.ClusterRoleBinding{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: "system:openshift:scc:privileged",
-		},
-		Subjects: []rbacv1.Subject{
-			{
-				Kind:     rbacv1.ServiceAccountKind,
-				APIGroup: rbacv1.GroupName,
-				Name:     pkg.SonobuoyServiceAccountName,
-			},
-		},
-		RoleRef: rbacv1.RoleRef{
-			APIGroup: rbacv1.GroupName,
-			Kind:     "ClusterRole",
-			Name:     "system:openshift:scc:privileged",
-		},
-	}
-
-	_, err = rbacClient.ClusterRoleBindings().Update(context.TODO(), anyuid, metav1.UpdateOptions{})
+	_, err = rbacClient.ClusterRoles().Update(context.TODO(), cr, metav1.UpdateOptions{})
 	if err != nil {
-		return errors.Wrap(err, "error creating anyuid ClusterRoleBinding")
+		return errors.Wrap(err, "error creating privileged ClusterRole")
 	}
-	log.Infof("Created %s ClusterRoleBinding", pkg.AnyUIDClusterRoleBinding)
+	log.Infof("Created %s ClusterRole", pkg.PrivilegedClusterRole)
 
-	_, err = rbacClient.ClusterRoleBindings().Update(context.TODO(), privileged, metav1.UpdateOptions{})
+	crb := &rbacv1.ClusterRoleBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      pkg.PrivilegedClusterRoleBinding,
+			Namespace: pkg.CertificationNamespace,
+			Labels:    pkg.SonobuoyDefaultLabels,
+		},
+		Subjects: []rbacv1.Subject{
+			{
+				Kind:      rbacv1.ServiceAccountKind,
+				Name:      pkg.SonobuoyServiceAccountName,
+				Namespace: pkg.CertificationNamespace,
+			},
+		},
+		RoleRef: rbacv1.RoleRef{
+			APIGroup: rbacv1.GroupName,
+			Kind:     "ClusterRole",
+			Name:     pkg.PrivilegedClusterRole,
+		},
+	}
+	crb.SetGroupVersionKind(schema.GroupVersionKind{
+		Group:   rbacv1.GroupName,
+		Version: "v1",
+		Kind:    "ClusterRoleBinding",
+	})
+
+	_, err = rbacClient.ClusterRoleBindings().Update(context.TODO(), crb, metav1.UpdateOptions{})
 	if err != nil {
 		return errors.Wrap(err, "error creating privileged ClusterRoleBinding")
 	}
@@ -370,12 +383,13 @@ func (r *RunOptions) Run(kclient kubernetes.Interface, sclient sonobuoyclient.In
 
 	// Ignore Existing SA created on preflight
 	aggConfig.ExistingServiceAccount = true
+	aggConfig.ServiceAccountName = pkg.SonobuoyServiceAccountName
 
 	// Fill out the Run configuration
 	runConfig := &sonobuoyclient.RunConfig{
 		GenConfig: sonobuoyclient.GenConfig{
 			Config:             aggConfig,
-			EnableRBAC:         true, // True because OpenShift uses RBAC
+			EnableRBAC:         false, // RBAC is created in preflight
 			ImagePullPolicy:    config.DefaultSonobuoyPullPolicy,
 			StaticPlugins:      manifests,
 			PluginEnvOverrides: nil, // TODO We'll use this later

--- a/pkg/types.go
+++ b/pkg/types.go
@@ -1,12 +1,21 @@
 package pkg
 
 const (
-	AnyUIDClusterRoleBinding       = "opct-anyuid"
-	PrivilegedClusterRoleBinding   = "opct-privileged"
+	PrivilegedClusterRole          = "opct-scc-privileged"
+	PrivilegedClusterRoleBinding   = "opct-scc-privileged"
 	CertificationNamespace         = "openshift-provider-certification"
 	VersionInfoConfigMapName       = "openshift-provider-certification-version"
 	DedicatedNodeRoleLabel         = "node-role.kubernetes.io/tests"
 	DedicatedNodeRoleLabelSelector = "node-role.kubernetes.io/tests="
 	SonobuoyServiceAccountName     = "sonobuoy-serviceaccount"
-	SonobuoyComponentLabelValue    = "sonobuoy"
+	SonobuoyLabelNamespaceName     = "namespace"
+	SonobuoyLabelComponentName     = "component"
+	SonobuoyLabelComponentValue    = "sonobuoy"
+)
+
+var (
+	SonobuoyDefaultLabels = map[string]string{
+		SonobuoyLabelComponentName: SonobuoyLabelComponentValue,
+		SonobuoyLabelNamespaceName: CertificationNamespace,
+	}
 )

--- a/pkg/types.go
+++ b/pkg/types.go
@@ -1,8 +1,12 @@
 package pkg
 
 const (
-	AnyUIDClusterRoleBinding     = "opct-anyuid"
-	PrivilegedClusterRoleBinding = "opct-privileged"
-	CertificationNamespace       = "openshift-provider-certification"
-	VersionInfoConfigMapName     = "openshift-provider-certification-version"
+	AnyUIDClusterRoleBinding       = "opct-anyuid"
+	PrivilegedClusterRoleBinding   = "opct-privileged"
+	CertificationNamespace         = "openshift-provider-certification"
+	VersionInfoConfigMapName       = "openshift-provider-certification-version"
+	DedicatedNodeRoleLabel         = "node-role.kubernetes.io/tests"
+	DedicatedNodeRoleLabelSelector = "node-role.kubernetes.io/tests="
+	SonobuoyServiceAccountName     = "sonobuoy-serviceaccount"
+	SonobuoyComponentLabelValue    = "sonobuoy"
 )


### PR DESCRIPTION
https://issues.redhat.com/browse/OPCT-6

This PR creates custom permissions to be used on Sonobuoy's service accounts.

The default sonobuoy's permissions are crashing the cluster upgrade feature (implemented on #33), described on OPCT-6. The goal is to avoid using system groups to not fall into pod admissions security admissions introduced on kube 1.24 (4.11).

The groups `system:authenticated` and `system:serviceaccounts` previously used were crashing the upgrade. Ref [KCS 5875621](https://access.redhat.com/solutions/5875621)

```
$ oc adm policy who-can use scc anyuid | grep serviceaccounts
        system:serviceaccounts 
```

Tests checklist:

- [x] Run a full test on regular mode on baseline platform (AWS) and check the results. Expected: no failures increased when comparing with latest baseline results payload
- [x] Run the full test on upgrade feature (SPLAT-651/#33) to validate full functional in both modes (regular and upgrade).