### PR TITLE
OPCT-7 - fix/scc: disable SCC creation by sonobuoy

### DIFF
--- a/pkg/run/run.go
+++ b/pkg/run/run.go
@@ -388,6 +388,7 @@ func (r *RunOptions) Run(kclient kubernetes.Interface, sclient sonobuoyclient.In
 	// Ignore Existing SA created on preflight
 	aggConfig.ExistingServiceAccount = true
 	aggConfig.ServiceAccountName = pkg.SonobuoyServiceAccountName
+	aggConfig.SecurityContextMode = "none"
 
 	// Fill out the Run configuration
 	runConfig := &sonobuoyclient.RunConfig{


### PR DESCRIPTION
The goal of this PR is to change the default mode of the SecurityContext creates the assets (aggregator and jobs). The SCC created by Sonobuoy is not working as expected on the pod admission security pods introduced on the OCP 4.11.

We get the issue when running upgrade from 4.10 to 4.11, the sonobuoy aggregator was stop annotating to the resources managed by it right after the cluster finished the upgrade. The issue is detailed on [OPCT-7](https://issues.redhat.com/browse/OPCT-7).