### PR TITLE
OPCT-32 - Dev env: enable dev-count flag to limit e2e list in runtime

### DIFF
--- a/manifests/openshift-conformance-validated.yaml
+++ b/manifests/openshift-conformance-validated.yaml
@@ -62,3 +62,8 @@ spec:
       valueFrom:
         fieldRef:
           fieldPath: metadata.namespace
+    - name: DEV_MODE_COUNT
+      valueFrom:
+        configMapKeyRef:
+          name: plugins-config
+          key: dev-count

--- a/manifests/openshift-kube-conformance.yaml
+++ b/manifests/openshift-kube-conformance.yaml
@@ -62,3 +62,8 @@ spec:
       valueFrom:
         fieldRef:
           fieldPath: metadata.namespace
+    - name: DEV_MODE_COUNT
+      valueFrom:
+        configMapKeyRef:
+          name: plugins-config
+          key: dev-count

--- a/pkg/assets/bindata.go
+++ b/pkg/assets/bindata.go
@@ -200,6 +200,11 @@ spec:
       valueFrom:
         fieldRef:
           fieldPath: metadata.namespace
+    - name: DEV_MODE_COUNT
+      valueFrom:
+        configMapKeyRef:
+          name: plugins-config
+          key: dev-count
 `)
 
 func manifestsOpenshiftConformanceValidatedYamlBytes() ([]byte, error) {
@@ -281,6 +286,11 @@ spec:
       valueFrom:
         fieldRef:
           fieldPath: metadata.namespace
+    - name: DEV_MODE_COUNT
+      valueFrom:
+        configMapKeyRef:
+          name: plugins-config
+          key: dev-count
 `)
 
 func manifestsOpenshiftKubeConformanceYamlBytes() ([]byte, error) {

--- a/pkg/types.go
+++ b/pkg/types.go
@@ -5,6 +5,7 @@ const (
 	PrivilegedClusterRoleBinding   = "opct-scc-privileged"
 	CertificationNamespace         = "openshift-provider-certification"
 	VersionInfoConfigMapName       = "openshift-provider-certification-version"
+	PluginsVarsConfigMapName       = "plugins-config"
 	DedicatedNodeRoleLabel         = "node-role.kubernetes.io/tests"
 	DedicatedNodeRoleLabelSelector = "node-role.kubernetes.io/tests="
 	SonobuoyServiceAccountName     = "sonobuoy-serviceaccount"


### PR DESCRIPTION
Intro to dev flag to allow developers fastly use the "e2e limit", feature of Plugins, when running a development environment.

To use the DEV_MODE env var on plugins, we need to change the plugins manifests and rebuild the CLI. It is very useful when I am trying other features on CLI or plugins, to make sure the complete flow is running, but with a small set of e2e (sometimes we don't need to check the e2e results, we want to know the flow will work).

But it's kinda boring to change the manifests every time and rebuild the CLI, it could be more useful when setting a CLI flag to run in "DEV MODE".

The quick implementation was done when running the upgrade feature, but a final change needs a more understanding of the impact of allowing this by default.

https://issues.redhat.com/browse/OPCT-32