### PR TITLE
OPCT-11 - fix/psa-warn: apply NS labels for PSA Level privileged

### DIFF
--- a/pkg/types.go
+++ b/pkg/types.go
@@ -17,5 +17,11 @@ var (
 	SonobuoyDefaultLabels = map[string]string{
 		SonobuoyLabelComponentName: SonobuoyLabelComponentValue,
 		SonobuoyLabelNamespaceName: CertificationNamespace,
+		// Enforcing privileged mode for PSA on Conformance/Sonobuoy environment.
+		// https://issues.redhat.com/browse/OPCT-11
+		// https://issues.redhat.com/browse/OPCT-31
+		"pod-security.kubernetes.io/enforce": "privileged",
+		"pod-security.kubernetes.io/audit":   "privileged",
+		"pod-security.kubernetes.io/warn":    "privileged",
 	}
 )


### PR DESCRIPTION
The goal of this PR is to provide the correct privileges to the namespace created to OPCT environment. The following warnings from PSA was introduced OCP 4.11:

```
# 4.11.24
$ KUBECONFIG=$PWD/.opct-41124/clusters/opct-41124/auth/kubeconfig oc logs sonobuoy -n openshift-provider-certification |grep 'would violate PodSecurity'
W0119 13:10:17.291197       1 warnings.go:70] would violate PodSecurity "restricted:latest": 
allowPrivilegeEscalation != false (containers "report-progress", "plugin", "sonobuoy-worker" must set securityContext.allowPrivilegeEscalation=false), 
unrestricted capabilities (containers "report-progress", "plugin", "sonobuoy-worker" must set securityContext.capabilities.drop=["ALL"]), 
runAsNonRoot != true (pod or containers "report-progress", "plugin", "sonobuoy-worker" must set securityContext.runAsNonRoot=true), 
seccompProfile (pod or containers "report-progress", "plugin", "sonobuoy-worker" must set securityContext.seccompProfile.type to "RuntimeDefault" or "Localhost")
(+3)

# 4.12.0
$ grep 'would violate PodSecurity' .opct-4120/clusters/opct-4120-2023011901/opct/results/podlogs/openshift-provider-certification/sonobuoy/logs/kube-sonobuoy.txt 
W0118 22:47:37.672610       1 warnings.go:70] would violate PodSecurity "restricted:latest": 
allowPrivilegeEscalation != false (containers "report-progress", "plugin", "sonobuoy-worker" must set securityContext.allowPrivilegeEscalation=false), 
unrestricted capabilities (containers "report-progress", "plugin", "sonobuoy-worker" must set securityContext.capabilities.drop=["ALL"]), 
runAsNonRoot != true (pod or containers "report-progress", "plugin", "sonobuoy-worker" must set securityContext.runAsNonRoot=true), 
seccompProfile (pod or containers "report-progress", "plugin", "sonobuoy-worker" must set securityContext.seccompProfile.type to "RuntimeDefault" or "Localhost")
```

Related cards:
- https://issues.redhat.com/browse/OPCT-11 (related but not resolve completely)
- https://issues.redhat.com/browse/OPCT-31 (upstream)

Tested on cluster versions:
- [ ]  4.10
- [ ]  4.11
- [ ]  4.12