### PR TITLE
OPCT-11: fix counters on plugin report progress

### DIFF
--- a/manifests/openshift-artifacts-collector.yaml
+++ b/manifests/openshift-artifacts-collector.yaml
@@ -6,7 +6,7 @@ podSpec:
       emptyDir: {}
   containers:
     - name: report-progress
-      image: quay.io/ocp-cert/openshift-tests-provider-cert:v0.3.0-alpha0
+      image: quay.io/ocp-cert/openshift-tests-provider-cert:v0.3.0-alpha1
       imagePullPolicy: Always
       priorityClassName: system-node-critical
       command: ["./report-progress.sh"]
@@ -39,7 +39,7 @@ sonobuoy-config:
   skipCleanup: true
 spec:
   name: plugin
-  image: quay.io/ocp-cert/openshift-tests-provider-cert:v0.3.0-alpha0
+  image: quay.io/ocp-cert/openshift-tests-provider-cert:v0.3.0-alpha1
   imagePullPolicy: Always
   volumeMounts:
   - mountPath: /tmp/sonobuoy/results

--- a/manifests/openshift-cluster-upgrade.yaml
+++ b/manifests/openshift-cluster-upgrade.yaml
@@ -6,7 +6,7 @@ podSpec:
       emptyDir: {}
   containers:
     - name: report-progress
-      image: quay.io/ocp-cert/openshift-tests-provider-cert:v0.3.0-alpha0
+      image: quay.io/ocp-cert/openshift-tests-provider-cert:v0.3.0-alpha1
       imagePullPolicy: Always
       priorityClassName: system-node-critical
       command: ["./report-progress.sh"]
@@ -39,7 +39,7 @@ sonobuoy-config:
   skipCleanup: true
 spec:
   name: plugin
-  image: quay.io/ocp-cert/openshift-tests-provider-cert:v0.3.0-alpha0
+  image: quay.io/ocp-cert/openshift-tests-provider-cert:v0.3.0-alpha1
   imagePullPolicy: Always
   priorityClassName: system-node-critical
   volumeMounts:

--- a/manifests/openshift-conformance-validated.yaml
+++ b/manifests/openshift-conformance-validated.yaml
@@ -6,7 +6,7 @@ podSpec:
       emptyDir: {}
   containers:
     - name: report-progress
-      image: quay.io/ocp-cert/openshift-tests-provider-cert:v0.3.0-alpha0
+      image: quay.io/ocp-cert/openshift-tests-provider-cert:v0.3.0-alpha1
       imagePullPolicy: Always
       priorityClassName: system-node-critical
       command: ["./report-progress.sh"]
@@ -39,7 +39,7 @@ sonobuoy-config:
   skipCleanup: true
 spec:
   name: plugin
-  image: quay.io/ocp-cert/openshift-tests-provider-cert:v0.3.0-alpha0
+  image: quay.io/ocp-cert/openshift-tests-provider-cert:v0.3.0-alpha1
   imagePullPolicy: Always
   priorityClassName: system-node-critical
   volumeMounts:

--- a/manifests/openshift-kube-conformance.yaml
+++ b/manifests/openshift-kube-conformance.yaml
@@ -6,7 +6,7 @@ podSpec:
       emptyDir: {}
   containers:
     - name: report-progress
-      image: quay.io/ocp-cert/openshift-tests-provider-cert:v0.3.0-alpha0
+      image: quay.io/ocp-cert/openshift-tests-provider-cert:v0.3.0-alpha1
       imagePullPolicy: Always
       priorityClassName: system-node-critical
       command: ["./report-progress.sh"]
@@ -39,7 +39,7 @@ sonobuoy-config:
   skipCleanup: true
 spec:
   name: plugin
-  image: quay.io/ocp-cert/openshift-tests-provider-cert:v0.3.0-alpha0
+  image: quay.io/ocp-cert/openshift-tests-provider-cert:v0.3.0-alpha1
   imagePullPolicy: Always
   priorityClassName: system-node-critical
   volumeMounts:

--- a/pkg/assets/bindata.go
+++ b/pkg/assets/bindata.go
@@ -64,7 +64,7 @@ var _manifestsOpenshiftArtifactsCollectorYaml = []byte(`podSpec:
       emptyDir: {}
   containers:
     - name: report-progress
-      image: quay.io/ocp-cert/openshift-tests-provider-cert:v0.3.0-alpha0
+      image: quay.io/ocp-cert/openshift-tests-provider-cert:v0.3.0-alpha1
       imagePullPolicy: Always
       priorityClassName: system-node-critical
       command: ["./report-progress.sh"]
@@ -97,7 +97,7 @@ sonobuoy-config:
   skipCleanup: true
 spec:
   name: plugin
-  image: quay.io/ocp-cert/openshift-tests-provider-cert:v0.3.0-alpha0
+  image: quay.io/ocp-cert/openshift-tests-provider-cert:v0.3.0-alpha1
   imagePullPolicy: Always
   volumeMounts:
   - mountPath: /tmp/sonobuoy/results
@@ -149,7 +149,7 @@ var _manifestsOpenshiftClusterUpgradeYaml = []byte(`podSpec:
       emptyDir: {}
   containers:
     - name: report-progress
-      image: quay.io/ocp-cert/openshift-tests-provider-cert:v0.3.0-alpha0
+      image: quay.io/ocp-cert/openshift-tests-provider-cert:v0.3.0-alpha1
       imagePullPolicy: Always
       priorityClassName: system-node-critical
       command: ["./report-progress.sh"]
@@ -182,7 +182,7 @@ sonobuoy-config:
   skipCleanup: true
 spec:
   name: plugin
-  image: quay.io/ocp-cert/openshift-tests-provider-cert:v0.3.0-alpha0
+  image: quay.io/ocp-cert/openshift-tests-provider-cert:v0.3.0-alpha1
   imagePullPolicy: Always
   priorityClassName: system-node-critical
   volumeMounts:
@@ -240,7 +240,7 @@ var _manifestsOpenshiftConformanceValidatedYaml = []byte(`podSpec:
       emptyDir: {}
   containers:
     - name: report-progress
-      image: quay.io/ocp-cert/openshift-tests-provider-cert:v0.3.0-alpha0
+      image: quay.io/ocp-cert/openshift-tests-provider-cert:v0.3.0-alpha1
       imagePullPolicy: Always
       priorityClassName: system-node-critical
       command: ["./report-progress.sh"]
@@ -273,7 +273,7 @@ sonobuoy-config:
   skipCleanup: true
 spec:
   name: plugin
-  image: quay.io/ocp-cert/openshift-tests-provider-cert:v0.3.0-alpha0
+  image: quay.io/ocp-cert/openshift-tests-provider-cert:v0.3.0-alpha1
   imagePullPolicy: Always
   priorityClassName: system-node-critical
   volumeMounts:
@@ -331,7 +331,7 @@ var _manifestsOpenshiftKubeConformanceYaml = []byte(`podSpec:
       emptyDir: {}
   containers:
     - name: report-progress
-      image: quay.io/ocp-cert/openshift-tests-provider-cert:v0.3.0-alpha0
+      image: quay.io/ocp-cert/openshift-tests-provider-cert:v0.3.0-alpha1
       imagePullPolicy: Always
       priorityClassName: system-node-critical
       command: ["./report-progress.sh"]
@@ -364,7 +364,7 @@ sonobuoy-config:
   skipCleanup: true
 spec:
   name: plugin
-  image: quay.io/ocp-cert/openshift-tests-provider-cert:v0.3.0-alpha0
+  image: quay.io/ocp-cert/openshift-tests-provider-cert:v0.3.0-alpha1
   imagePullPolicy: Always
   priorityClassName: system-node-critical
   volumeMounts:


### PR DESCRIPTION
https://issues.redhat.com/browse/OPCT-11

Bump to v0.3.0-alpha1 after plugin fix https://github.com/redhat-openshift-ecosystem/provider-certification-plugins/pull/34

This PR will improve the counters when running OPCT, fixing a bug on openshift-tests on 4.12+ clusters.

We don't need to create a alpha release for CLI, but having this change on the master will get newer results from OpenShift CI, running weekly for 4.12.