### PR TITLE
OPCT-36: Documentation - create static website with GHPages

### DIFF
--- a/.github/workflows/static-website.yml
+++ b/.github/workflows/static-website.yml
@@ -1,0 +1,48 @@
+# Simple workflow for deploying static content to GitHub Pages
+name: Deploy static content to Pages
+
+on:
+  # Runs on pushes targeting the default branch
+  push:
+    branches: ["main"]
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Allow one concurrent deployment
+concurrency:
+  group: "pages"
+  cancel-in-progress: true
+
+jobs:
+  # Single deploy job since we're just deploying
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Build mkdocs website
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y python3-pip
+          pip3 install -r hack/docs-requirements.txt
+          mkdocs build --site-dir ./site
+      - name: Setup Pages
+        uses: actions/configure-pages@v3
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v1
+        with:
+          # Upload entire repository
+          path: './site'
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v1

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,6 +1,7 @@
 site_name: OpenShift Provider Certification Tool
 site_description: >-
   OpenShift Provider Certification Tool | Guide
+site_url: https://redhat-openshift-ecosystem.github.io/provider-certification-tool
 repo_url: https://github.com/redhat-openshift-ecosystem/provider-certification-tool
 edit_uri: edit/main/docs/
 docs_dir: ./docs


### PR DESCRIPTION
Initial setup to create a mkdocs website build to publish a documentation page into Github Pages: https://redhat-openshift-ecosystem.github.io/provider-certification-tool