### PR TITLE
bump plugin image to v0.2.2

### DIFF
--- a/manifests/openshift-artifacts-collector.yaml
+++ b/manifests/openshift-artifacts-collector.yaml
@@ -6,7 +6,7 @@ podSpec:
       emptyDir: {}
   containers:
     - name: report-progress
-      image: quay.io/ocp-cert/openshift-tests-provider-cert:v0.2.1
+      image: quay.io/ocp-cert/openshift-tests-provider-cert:v0.2.2
       imagePullPolicy: Always
       priorityClassName: system-node-critical
       command: ["./report-progress.sh"]
@@ -39,7 +39,7 @@ sonobuoy-config:
   skipCleanup: true
 spec:
   name: plugin
-  image: quay.io/ocp-cert/openshift-tests-provider-cert:v0.2.1
+  image: quay.io/ocp-cert/openshift-tests-provider-cert:v0.2.2
   imagePullPolicy: Always
   priorityClassName: system-node-critical
   volumeMounts:

--- a/manifests/openshift-conformance-validated.yaml
+++ b/manifests/openshift-conformance-validated.yaml
@@ -6,7 +6,7 @@ podSpec:
       emptyDir: {}
   containers:
     - name: report-progress
-      image: quay.io/ocp-cert/openshift-tests-provider-cert:v0.2.1
+      image: quay.io/ocp-cert/openshift-tests-provider-cert:v0.2.2
       imagePullPolicy: Always
       priorityClassName: system-node-critical
       command: ["./report-progress.sh"]
@@ -39,7 +39,7 @@ sonobuoy-config:
   skipCleanup: true
 spec:
   name: plugin
-  image: quay.io/ocp-cert/openshift-tests-provider-cert:v0.2.1
+  image: quay.io/ocp-cert/openshift-tests-provider-cert:v0.2.2
   imagePullPolicy: Always
   priorityClassName: system-node-critical
   volumeMounts:

--- a/manifests/openshift-kube-conformance.yaml
+++ b/manifests/openshift-kube-conformance.yaml
@@ -6,7 +6,7 @@ podSpec:
       emptyDir: {}
   containers:
     - name: report-progress
-      image: quay.io/ocp-cert/openshift-tests-provider-cert:v0.2.1
+      image: quay.io/ocp-cert/openshift-tests-provider-cert:v0.2.2
       imagePullPolicy: Always
       priorityClassName: system-node-critical
       command: ["./report-progress.sh"]
@@ -39,7 +39,7 @@ sonobuoy-config:
   skipCleanup: true
 spec:
   name: plugin
-  image: quay.io/ocp-cert/openshift-tests-provider-cert:v0.2.1
+  image: quay.io/ocp-cert/openshift-tests-provider-cert:v0.2.2
   imagePullPolicy: Always
   priorityClassName: system-node-critical
   volumeMounts:

--- a/pkg/assets/bindata.go
+++ b/pkg/assets/bindata.go
@@ -63,7 +63,7 @@ var _manifestsOpenshiftArtifactsCollectorYaml = []byte(`podSpec:
       emptyDir: {}
   containers:
     - name: report-progress
-      image: quay.io/ocp-cert/openshift-tests-provider-cert:v0.2.1
+      image: quay.io/ocp-cert/openshift-tests-provider-cert:v0.2.2
       imagePullPolicy: Always
       priorityClassName: system-node-critical
       command: ["./report-progress.sh"]
@@ -96,7 +96,7 @@ sonobuoy-config:
   skipCleanup: true
 spec:
   name: plugin
-  image: quay.io/ocp-cert/openshift-tests-provider-cert:v0.2.1
+  image: quay.io/ocp-cert/openshift-tests-provider-cert:v0.2.2
   imagePullPolicy: Always
   priorityClassName: system-node-critical
   volumeMounts:
@@ -144,7 +144,7 @@ var _manifestsOpenshiftConformanceValidatedYaml = []byte(`podSpec:
       emptyDir: {}
   containers:
     - name: report-progress
-      image: quay.io/ocp-cert/openshift-tests-provider-cert:v0.2.1
+      image: quay.io/ocp-cert/openshift-tests-provider-cert:v0.2.2
       imagePullPolicy: Always
       priorityClassName: system-node-critical
       command: ["./report-progress.sh"]
@@ -177,7 +177,7 @@ sonobuoy-config:
   skipCleanup: true
 spec:
   name: plugin
-  image: quay.io/ocp-cert/openshift-tests-provider-cert:v0.2.1
+  image: quay.io/ocp-cert/openshift-tests-provider-cert:v0.2.2
   imagePullPolicy: Always
   priorityClassName: system-node-critical
   volumeMounts:
@@ -225,7 +225,7 @@ var _manifestsOpenshiftKubeConformanceYaml = []byte(`podSpec:
       emptyDir: {}
   containers:
     - name: report-progress
-      image: quay.io/ocp-cert/openshift-tests-provider-cert:v0.2.1
+      image: quay.io/ocp-cert/openshift-tests-provider-cert:v0.2.2
       imagePullPolicy: Always
       priorityClassName: system-node-critical
       command: ["./report-progress.sh"]
@@ -258,7 +258,7 @@ sonobuoy-config:
   skipCleanup: true
 spec:
   name: plugin
-  image: quay.io/ocp-cert/openshift-tests-provider-cert:v0.2.1
+  image: quay.io/ocp-cert/openshift-tests-provider-cert:v0.2.2
   imagePullPolicy: Always
   priorityClassName: system-node-critical
   volumeMounts:


### PR DESCRIPTION
Back port plugin changes:
- https://github.com/redhat-openshift-ecosystem/provider-certification-plugins/pull/33
- https://github.com/redhat-openshift-ecosystem/provider-certification-plugins/pull/32

https://issues.redhat.com/browse/SPLAT-646
