### PR TITLE
OPCT-28: Support Disconnected Mirror Registry

### DIFF
--- a/docs/user-installation-disconnected.md
+++ b/docs/user-installation-disconnected.md
@@ -3,8 +3,8 @@
 ## Prerequisites/Requirements
 
 - Disconnected Mirror Image Registry created
-- Private cluster Installed: https://docs.openshift.com/container-platform/latest/installing/installing_bare_metal/installing-restricted-networks-bare-metal.html
-- You created a registry on your mirror host: https://docs.openshift.com/container-platform/latest/installing/disconnected_install/installing-mirroring-installation-images.html#installing-mirroring-installation-images
+- [Private cluster Installed](https://docs.openshift.com/container-platform/latest/installing/installing_bare_metal/installing-restricted-networks-bare-metal.html)
+- [You created a registry on your mirror host](https://docs.openshift.com/container-platform/latest/installing/disconnected_install/installing-mirroring-installation-images.html#installing-mirroring-installation-images)
 
 ## Configuring the Disconnected Mirror Registry
 1. Extract the `openshift-tests` executable associated with the version of OpenShift you are installing.
@@ -34,7 +34,7 @@ echo "quay.io/ocp-cert/sonobuoy:${SONOBUOY_TAG} ${SONOBUOY_TARGET}" >> images-to
 4. Append the OPCT tools image to the `images-to-mirror` list
 
 ~~~
-OPCT_VERSION=v0.3.0-alpha1
+OPCT_VERSION=v0.4.0-alpha1
 OPCT_TARGET=${TARGET_REPO}/openshift-tests-provider-cert:${OPCT_VERSION}
 echo "quay.io/ocp-cert/openshift-tests-provider-cert:${OPCT_VERSION} ${OPCT_TARGET}" >> images-to-mirror
 ~~~

--- a/docs/user-installation-disconnected.md
+++ b/docs/user-installation-disconnected.md
@@ -1,0 +1,56 @@
+# User Installation Guide - Disconnected Installations
+
+## Prerequisites/Requirements
+
+- Disconnected Mirror Image Registry created
+- Private cluster Installed: https://docs.openshift.com/container-platform/latest/installing/installing_bare_metal/installing-restricted-networks-bare-metal.html
+- You created a registry on your mirror host: https://docs.openshift.com/container-platform/latest/installing/disconnected_install/installing-mirroring-installation-images.html#installing-mirroring-installation-images
+
+## Configuring the Disconnected Mirror Registry
+1. Extract the `openshift-tests` executable associated with the version of OpenShift you are installing.
+_Note:_ The pull secret must contain both your OpenShift pull secret as well credentials for the disconnected
+mirror registry.
+~~~
+PULL_SECRET=/path/to/pull-secret
+OPENSHIFT_TESTS_IMAGE=$(oc get is -n openshift tests -o=jsonpath='{.spec.tags[0].from.name}')
+oc image extract -a ${PULL_SECRET} "${OPENSHIFT_TESTS_IMAGE}" --file="/usr/bin/openshift-tests"
+chmod +x openshift-tests
+~~~
+
+2. Extract the images and the location to where they are to be mirrored from the `openshift-tests` executable.  
+
+~~~
+TARGET_REPO=target-registry.net/ocp-cert
+./openshift-tests images --to-repository ${TARGET_REPO} > images-to-mirror
+~~~
+
+3. Append Sonobuoy to the `images-to-mirror` list
+~~~
+SONOBUOY_TAG=$(./openshift-provider-cert-linux-amd64 version | grep "Sonobuoy Version:" | cut -d' ' -f 3)
+SONOBUOY_TARGET=${TARGET_REPO}/sonobuoy:${SONOBUOY_TAG}
+echo "quay.io/ocp-cert/sonobuoy:${SONOBUOY_TAG} ${SONOBUOY_TARGET}" >> images-to-mirror
+~~~
+
+4. Append the OPCT tools image to the `images-to-mirror` list
+
+~~~
+OPCT_VERSION=v0.3.0-alpha1
+OPCT_TARGET=${TARGET_REPO}/openshift-tests-provider-cert:${OPCT_VERSION}
+echo "quay.io/ocp-cert/openshift-tests-provider-cert:${OPCT_VERSION} ${OPCT_TARGET}" >> images-to-mirror
+~~~
+
+5. Mirror the images to the disconnected mirror registry
+
+~~~
+oc image mirror -a ${PULL_SECRET} -f images-to-mirror
+~~~
+
+
+## Preparing Your Cluster
+
+- The Insights operator must be disabled prior to to running tests.  See [Disabling insights operator](https://docs.openshift.com/container-platform/latest/support/remote_health_monitoring/opting-out-of-remote-health-reporting.html)
+- The [Image Registry Operator](https://docs.openshift.com/container-platform/latest/registry/index.html) must be configured and available
+
+
+
+For additional details and configuration options, see [OpenShift Provider Certification Tool - User Guide](./user.md).

--- a/docs/user.md
+++ b/docs/user.md
@@ -13,6 +13,7 @@ Table Of Contents:
     - [Standard Environment](#standard-env)
         - [Setup Dedicated Node](#standard-env-setup-node)
         - [Setup MachineConfigPool (upgrade mode)](#standard-env-setup-mcp)
+        - [Testing in a Disconnected Environment](#disconnected-env-setup)
     - [Privilege Requirements](#priv-requirements)
 - [Install](#install)
     - [Prebuilt Binary](#install-bin)
@@ -150,6 +151,13 @@ Make sure the `MachineConfigPool` has been created correctly:
 oc get machineconfigpool opct
 ```
 
+#### Testing in a Disconnected Environment <a name="disconnected-env-setup"></a>
+
+The OpenShift Provider Certification Tool requires numerous images during the setup and execution
+of tests.  See [User Installation Guide - Disconnected Installations](./user-installation-disconnected.md) for details 
+on how to configure a mirror registry and how to run the OpenShift Provider Certification Tool to rely on the mirror 
+registry for images.
+
 ### Privilege Requirements <a name="priv-requirements"></a>
 
 A user with [cluster administrator privilege](https://docs.openshift.com/container-platform/latest/authentication/using-rbac.html#creating-cluster-admin_using-rbac) must be used to run the provider certification tool. You also use the default `kubeadmin` user if you wish.
@@ -202,6 +210,23 @@ Requirements for running 'upgrade' mode:
 ```sh
 openshift-provider-cert run --mode=upgrade --upgrade-to-image=$(oc adm release info 4.Y+1.Z -o jsonpath={.image})
 ```
+
+## Run Tests with the Disconnected Mirror registry<a name="usage-run-disconnected"></a>
+
+Tests are able to be run in a disconnected environment through the use of a mirror registry.
+
+Requirements for running tests with a disconnected mirror registry:
+
+- Disconnected Mirror Image Registry created
+- Private cluster Installed: https://docs.openshift.com/container-platform/latest/installing/installing_bare_metal/installing-restricted-networks-bare-metal.html
+- You created a registry on your mirror host: https://docs.openshift.com/container-platform/latest/installing/disconnected_install/installing-mirroring-installation-images.html#installing-mirroring-installation-images
+
+
+To run tests such that they use images hosted by the Disconnected Mirror registry:
+
+~~~
+./openshift-provider-cert-linux-amd64 run --image-repository ${TARGET_REPO}
+~~~
 
 #### Optional parameters for run <a name="usage-run-optional"></a>
 

--- a/manifests/openshift-artifacts-collector.yaml
+++ b/manifests/openshift-artifacts-collector.yaml
@@ -6,7 +6,7 @@ podSpec:
       emptyDir: {}
   containers:
     - name: report-progress
-      image: quay.io/ocp-cert/openshift-tests-provider-cert:v0.3.0
+      image: "{{ .ToolsImage }}"
       imagePullPolicy: Always
       priorityClassName: system-node-critical
       command: ["./report-progress.sh"]
@@ -39,7 +39,7 @@ sonobuoy-config:
   skipCleanup: true
 spec:
   name: plugin
-  image: quay.io/ocp-cert/openshift-tests-provider-cert:v0.3.0
+  image: "{{ .ToolsImage }}"
   imagePullPolicy: Always
   volumeMounts:
   - mountPath: /tmp/sonobuoy/results
@@ -71,3 +71,10 @@ spec:
         configMapKeyRef:
           name: plugins-config
           key: upgrade-target-images
+    - name: MIRROR_IMAGE_REPOSITORY
+      valueFrom:
+        configMapKeyRef:
+          name: plugins-config
+          key: mirror-registry
+          optional: true
+

--- a/manifests/openshift-cluster-upgrade.yaml
+++ b/manifests/openshift-cluster-upgrade.yaml
@@ -6,7 +6,7 @@ podSpec:
       emptyDir: {}
   containers:
     - name: report-progress
-      image: quay.io/ocp-cert/openshift-tests-provider-cert:v0.3.0
+      image: "{{ .ToolsImage }}"
       imagePullPolicy: Always
       priorityClassName: system-node-critical
       command: ["./report-progress.sh"]
@@ -39,7 +39,7 @@ sonobuoy-config:
   skipCleanup: true
 spec:
   name: plugin
-  image: quay.io/ocp-cert/openshift-tests-provider-cert:v0.3.0
+  image: "{{ .ToolsImage }}"
   imagePullPolicy: Always
   priorityClassName: system-node-critical
   volumeMounts:
@@ -72,3 +72,10 @@ spec:
         configMapKeyRef:
           name: plugins-config
           key: run-mode
+    - name: MIRROR_IMAGE_REPOSITORY
+      valueFrom:
+        configMapKeyRef:
+          name: plugins-config
+          key: mirror-registry
+          optional: true
+

--- a/manifests/openshift-conformance-validated.yaml
+++ b/manifests/openshift-conformance-validated.yaml
@@ -6,7 +6,7 @@ podSpec:
       emptyDir: {}
   containers:
     - name: report-progress
-      image: quay.io/ocp-cert/openshift-tests-provider-cert:v0.3.0
+      image: "{{ .ToolsImage }}"
       imagePullPolicy: Always
       priorityClassName: system-node-critical
       command: ["./report-progress.sh"]
@@ -39,7 +39,7 @@ sonobuoy-config:
   skipCleanup: true
 spec:
   name: plugin
-  image: quay.io/ocp-cert/openshift-tests-provider-cert:v0.3.0
+  image: "{{ .ToolsImage }}"
   imagePullPolicy: Always
   priorityClassName: system-node-critical
   volumeMounts:
@@ -72,3 +72,9 @@ spec:
         configMapKeyRef:
           name: plugins-config
           key: dev-count
+    - name: MIRROR_IMAGE_REPOSITORY
+      valueFrom:
+        configMapKeyRef:
+          name: plugins-config
+          key: mirror-registry
+          optional: true

--- a/manifests/openshift-kube-conformance.yaml
+++ b/manifests/openshift-kube-conformance.yaml
@@ -6,7 +6,7 @@ podSpec:
       emptyDir: {}
   containers:
     - name: report-progress
-      image: quay.io/ocp-cert/openshift-tests-provider-cert:v0.3.0
+      image: "{{ .ToolsImage }}"
       imagePullPolicy: Always
       priorityClassName: system-node-critical
       command: ["./report-progress.sh"]
@@ -39,7 +39,7 @@ sonobuoy-config:
   skipCleanup: true
 spec:
   name: plugin
-  image: quay.io/ocp-cert/openshift-tests-provider-cert:v0.3.0
+  image: "{{ .ToolsImage }}"
   imagePullPolicy: Always
   priorityClassName: system-node-critical
   volumeMounts:
@@ -72,3 +72,9 @@ spec:
         configMapKeyRef:
           name: plugins-config
           key: dev-count
+    - name: MIRROR_IMAGE_REPOSITORY
+      valueFrom:
+        configMapKeyRef:
+          name: plugins-config
+          key: mirror-registry
+          optional: true

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -33,6 +33,7 @@ nav:
     - "User Guide": "user.md"
     - "Installation Checklist": user-installation-checklist.md
     - "Installation Review": user-installation-review.md
+    - "Disconnected Installations": user-installation-disconnected.md
     - "Troubleshooting": troubleshooting-guide.md
   - Support Guides:
     - Support Guide: support-guide.md

--- a/pkg/assets/bindata.go
+++ b/pkg/assets/bindata.go
@@ -64,7 +64,7 @@ var _manifestsOpenshiftArtifactsCollectorYaml = []byte(`podSpec:
       emptyDir: {}
   containers:
     - name: report-progress
-      image: quay.io/ocp-cert/openshift-tests-provider-cert:v0.3.0
+      image: "{{ .ToolsImage }}"
       imagePullPolicy: Always
       priorityClassName: system-node-critical
       command: ["./report-progress.sh"]
@@ -97,7 +97,7 @@ sonobuoy-config:
   skipCleanup: true
 spec:
   name: plugin
-  image: quay.io/ocp-cert/openshift-tests-provider-cert:v0.3.0
+  image: "{{ .ToolsImage }}"
   imagePullPolicy: Always
   volumeMounts:
   - mountPath: /tmp/sonobuoy/results
@@ -161,7 +161,7 @@ var _manifestsOpenshiftClusterUpgradeYaml = []byte(`podSpec:
       emptyDir: {}
   containers:
     - name: report-progress
-      image: quay.io/ocp-cert/openshift-tests-provider-cert:v0.3.0
+      image: "{{ .ToolsImage }}"
       imagePullPolicy: Always
       priorityClassName: system-node-critical
       command: ["./report-progress.sh"]
@@ -194,7 +194,7 @@ sonobuoy-config:
   skipCleanup: true
 spec:
   name: plugin
-  image: quay.io/ocp-cert/openshift-tests-provider-cert:v0.3.0
+  image: "{{ .ToolsImage }}"
   imagePullPolicy: Always
   priorityClassName: system-node-critical
   volumeMounts:
@@ -259,7 +259,7 @@ var _manifestsOpenshiftConformanceValidatedYaml = []byte(`podSpec:
       emptyDir: {}
   containers:
     - name: report-progress
-      image: quay.io/ocp-cert/openshift-tests-provider-cert:v0.3.0
+      image: "{{ .ToolsImage }}"
       imagePullPolicy: Always
       priorityClassName: system-node-critical
       command: ["./report-progress.sh"]
@@ -292,7 +292,7 @@ sonobuoy-config:
   skipCleanup: true
 spec:
   name: plugin
-  image: quay.io/ocp-cert/openshift-tests-provider-cert:v0.3.0
+  image: "{{ .ToolsImage }}"
   imagePullPolicy: Always
   priorityClassName: system-node-critical
   volumeMounts:
@@ -356,7 +356,7 @@ var _manifestsOpenshiftKubeConformanceYaml = []byte(`podSpec:
       emptyDir: {}
   containers:
     - name: report-progress
-      image: quay.io/ocp-cert/openshift-tests-provider-cert:v0.3.0
+      image: "{{ .ToolsImage }}"
       imagePullPolicy: Always
       priorityClassName: system-node-critical
       command: ["./report-progress.sh"]
@@ -389,7 +389,7 @@ sonobuoy-config:
   skipCleanup: true
 spec:
   name: plugin
-  image: quay.io/ocp-cert/openshift-tests-provider-cert:v0.3.0
+  image: "{{ .ToolsImage }}"
   imagePullPolicy: Always
   priorityClassName: system-node-critical
   volumeMounts:

--- a/pkg/assets/bindata.go
+++ b/pkg/assets/bindata.go
@@ -129,6 +129,13 @@ spec:
         configMapKeyRef:
           name: plugins-config
           key: upgrade-target-images
+    - name: MIRROR_IMAGE_REPOSITORY
+      valueFrom:
+        configMapKeyRef:
+          name: plugins-config
+          key: mirror-registry
+          optional: true
+
 `)
 
 func manifestsOpenshiftArtifactsCollectorYamlBytes() ([]byte, error) {
@@ -220,6 +227,13 @@ spec:
         configMapKeyRef:
           name: plugins-config
           key: run-mode
+    - name: MIRROR_IMAGE_REPOSITORY
+      valueFrom:
+        configMapKeyRef:
+          name: plugins-config
+          key: mirror-registry
+          optional: true
+
 `)
 
 func manifestsOpenshiftClusterUpgradeYamlBytes() ([]byte, error) {
@@ -311,6 +325,12 @@ spec:
         configMapKeyRef:
           name: plugins-config
           key: dev-count
+    - name: MIRROR_IMAGE_REPOSITORY
+      valueFrom:
+        configMapKeyRef:
+          name: plugins-config
+          key: mirror-registry
+          optional: true
 `)
 
 func manifestsOpenshiftConformanceValidatedYamlBytes() ([]byte, error) {
@@ -402,6 +422,12 @@ spec:
         configMapKeyRef:
           name: plugins-config
           key: dev-count
+    - name: MIRROR_IMAGE_REPOSITORY
+      valueFrom:
+        configMapKeyRef:
+          name: plugins-config
+          key: mirror-registry
+          optional: true
 `)
 
 func manifestsOpenshiftKubeConformanceYamlBytes() ([]byte, error) {

--- a/pkg/types.go
+++ b/pkg/types.go
@@ -12,6 +12,8 @@ const (
 	SonobuoyLabelNamespaceName     = "namespace"
 	SonobuoyLabelComponentName     = "component"
 	SonobuoyLabelComponentValue    = "sonobuoy"
+	DefaultToolsRepository         = "quay.io/ocp-cert"
+	PluginsImage                   = "openshift-tests-provider-cert:v0.3.0-alpha1"
 )
 
 var (

--- a/pkg/types.go
+++ b/pkg/types.go
@@ -13,7 +13,7 @@ const (
 	SonobuoyLabelComponentName     = "component"
 	SonobuoyLabelComponentValue    = "sonobuoy"
 	DefaultToolsRepository         = "quay.io/ocp-cert"
-	PluginsImage                   = "openshift-tests-provider-cert:v0.3.0-alpha1"
+	PluginsImage                   = "openshift-tests-provider-cert:v0.4.0-alpha1"
 )
 
 var (


### PR DESCRIPTION
Introduces a new argument to the `run` command called `--image-repository` .  When provided the `--image-repository`  argument, the tool will look to the provided registry as the source of images.