### PR TITLE
OPCT-191: Build and publish the CLI image to registry

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -39,3 +39,19 @@ jobs:
         with:
           files: |
             openshift-provider-cert*
+
+      - name: Build Container and Release to Quay
+        env:
+          VERSION: ${{ steps.get_version.outputs.VERSION }}
+          IMAGE: quay.io/ocp-cert/opct
+          QUAY_USER: ${{ secrets.QUAY_USER }}
+          QUAY_PASS: ${{ secrets.QUAY_PASS }}
+        run: |
+          echo "> Logging to Quay.io:"
+          podman login -u="${QUAY_USER}" -p="${QUAY_PASS}" quay.io
+
+          echo "> Build container image:"
+          podman build -t ${IMAGE}:${VERSION} -f hack/Containerfile.ci .
+
+          echo "> Publish container image:"
+          podman push ${IMAGE}:${VERSION}

--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,7 @@ export GO111MODULE=on
 # Disable CGO so that we always generate static binaries:
 export CGO_ENABLED=0
 
+IMG ?= quay.io/ocp-cert/opct
 VERSION=$(shell git rev-parse --short HEAD)
 RELEASE_TAG ?= 0.0.0
 
@@ -13,7 +14,7 @@ GO_BUILD_FLAGS := -ldflags '-s -w -X github.com/redhat-openshift-ecosystem/provi
 unexport GOFLAGS
 
 .PHONY: all
-all: linux-amd64 cross-build-windows-amd64 cross-build-darwin-amd64 cross-build-darwin-arm64
+all: linux-amd64 linux-amd64-container cross-build-windows-amd64 cross-build-darwin-amd64 cross-build-darwin-arm64
 
 .PHONY: build
 build:
@@ -43,6 +44,9 @@ cross-build-darwin-amd64:
 cross-build-darwin-arm64:
 	GOOS=darwin GOARCH=arm64 go build -o openshift-provider-cert-darwin-arm64 $(GO_BUILD_FLAGS)
 
+.PHONY: linux-amd64-container
+linux-amd64-container:
+	podman build -t $(IMG):latest -f hack/Containerfile --build-arg=RELEASE_TAG=$(RELEASE_TAG) .
 
 .PHONY: test
 test:

--- a/docs/dev.md
+++ b/docs/dev.md
@@ -17,11 +17,13 @@ Table of Contents:
 ## Release <a name="release"></a>
 
 Releasing a new version of the provider certification tool is done automatically through [this GitHub Action](https://github.com/redhat-openshift-ecosystem/provider-certification-tool/blob/main/.github/workflows/release.yaml)
-which is run on new tags. Tags should be named in format: v0.1.0. 
+which is run on new tags. Tags should the SemVer format. Example: v0.1.0, v0.1.0-alpha1 (...)
 
 Tags should only be created from the `main` branch which only accepts pull-requests that pass through [this CI GitHub Action](https://github.com/redhat-openshift-ecosystem/provider-certification-tool/blob/main/.github/workflows/go.yaml).
 
-Note that any version in v0.* will be considered part of the preview release of the certification tool.
+The container image for CLI is automatically published to the container registry [`quay.io/ocp-cert/opct`](https://quay.io/repository/ocp-cert/opct?tab=tags) by Github Action job `Build Container and Release to Quay` every new release.
+
+Note that any version in v0.* will be considered part of the **preview release** of the tool.
 
 ## Development Notes <a name="dev-notes"></a>
 

--- a/hack/Containerfile
+++ b/hack/Containerfile
@@ -1,0 +1,18 @@
+
+FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.19-openshift-4.13 AS builder
+ARG RELEASE_TAG
+WORKDIR /go/src/github.com/redhat-openshift-ecosystem/provider-certification-tool
+COPY . .
+RUN make linux-amd64 RELEASE_TAG=${RELEASE_TAG}
+
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.7-1085.1679482090
+LABEL io.k8s.display-name="OPCT" \
+      io.k8s.description="OpenShift/OKD Conformance Tool is designed to run conformance suites to validate custom installations." \
+      io.opct.tags="opct,conformance,openshift,tests,e2e" \
+      io.opct.os="linux" io.opct.arch="amd64"
+
+COPY --from=builder \
+      /go/src/github.com/redhat-openshift-ecosystem/provider-certification-tool/openshift-provider-cert-linux-amd64 \
+      /usr/bin/
+
+CMD ["/usr/bin/openshift-provider-cert-linux-amd64"]

--- a/hack/Containerfile.ci
+++ b/hack/Containerfile.ci
@@ -1,0 +1,9 @@
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.7-1085.1679482090
+LABEL io.k8s.display-name="OPCT" \
+      io.k8s.description="OpenShift/OKD Conformance Tool is designed to run conformance suites to validate custom installations." \
+      io.opct.tags="opct,conformance,openshift,tests,e2e" \
+      io.opct.os="linux" io.opct.arch="amd64"
+
+COPY ./openshift-provider-cert-linux-amd64 /usr/bin/
+
+CMD ["/usr/bin/opct"]


### PR DESCRIPTION
https://issues.redhat.com/browse/OPCT-191

This PR introduces the CLI container image, publishing it on Quay.io to allow be mirrored by OpenShift CI jobs (https://github.com/openshift/release/pull/37955), decreasing the complexity and logic of the CI steps.

https://quay.io/repository/ocp-cert/opct?tab=tags
