### PR TITLE
OPCT-192: Automatically create changelog based on the tags

### DIFF
--- a/.github/workflows/changelog-configuration.json
+++ b/.github/workflows/changelog-configuration.json
@@ -1,0 +1,73 @@
+{
+  "categories": [
+    {
+      "title": "## 🚀 Features",
+      "labels": ["feature", "kind/feature"]
+    },
+    {
+      "title": "## 🛰 Design / API Change",
+      "labels": ["design", "kind/design", "kind/api-change"]
+    },
+    {
+      "title": "## 🐛 Fixes",
+      "labels": ["fix", "kind/bug"]
+    },
+    {
+      "title": "## 🧪 Tests",
+      "labels": ["test", "kind/flake", "kind/failing-test"]
+    },
+    {
+      "title": "## ⛏ Cleanup",
+      "labels": ["cleanup", "kind/cleanup"]
+    },
+    {
+        "title": "## 📦 Dependencies",
+        "labels": ["dependencies", "kind/dependency-change"]
+    },
+    {
+        "title": "## 📜 Documentation",
+        "labels": ["docs", "documentation", "kind/documentation"]
+    },
+    {
+      "title": "## 💬 Other",
+      "labels": ["other"]
+    }
+  ],
+  "ignore_labels": [
+    "ignore"
+  ],
+  "sort": {
+    "order": "ASC",
+    "on_property": "mergedAt"
+  },
+  "template": "${{CHANGELOG}}\n\n<details>\n<summary>Uncategorized</summary>\n\n${{UNCATEGORIZED}}\n</details>",
+  "pr_template": "- ${{TITLE}}\n   - PR: #${{NUMBER}}",
+  "empty_template": "- no changes",
+  "label_extractor": [
+    {
+      "pattern": "(.) (.+)",
+      "target": "$1",
+      "flags": "gu"
+    },
+    {
+      "pattern": "\\[Issue\\]",
+      "on_property": "title",
+      "method": "match"
+    }
+  ],
+  "duplicate_filter": {
+    "pattern": "\\[ABC-....\\]",
+    "on_property": "title",
+    "method": "match"
+  },
+  "transformers": [
+    {
+      "pattern": "[\\-\\*] (\\[(...|TEST|CI|SKIP)\\])( )?(.+?)\n(.+?[\\-\\*] )(.+)",
+      "target": "- $4\n  - $6"
+    }
+  ],
+  "trim_values": false,
+  "max_tags_to_fetch": 200,
+  "max_pull_requests": 200,
+  "max_back_track_time_days": 365
+}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -32,14 +32,6 @@ jobs:
         env:
           RELEASE_TAG: ${{ github.ref_name }}
 
-      - name: Release
-        uses: softprops/action-gh-release@v0.1.15
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          files: |
-            openshift-provider-cert*
-
       - name: Build Container and Release to Quay
         env:
           VERSION: ${{ steps.get_version.outputs.VERSION }}
@@ -55,3 +47,24 @@ jobs:
 
           echo "> Publish container image:"
           podman push ${IMAGE}:${VERSION}
+
+      # https://github.com/mikepenz/release-changelog-builder-action#configuration
+      - name: Build Changelog
+        id: github_release
+        uses: mikepenz/release-changelog-builder-action@v3.7.0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          configuration: ".github/workflows/changelog-configuration.json"
+
+      # https://github.com/softprops/action-gh-release
+      - name: Create Release
+        uses: softprops/action-gh-release@v0.1.15
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          files: |
+            openshift-provider-cert*
+          body: |
+            ## Changelog
+            ${{steps.github_release.outputs.changelog}}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -32,22 +32,6 @@ jobs:
         env:
           RELEASE_TAG: ${{ github.ref_name }}
 
-      - name: Build Container and Release to Quay
-        env:
-          VERSION: ${{ steps.get_version.outputs.VERSION }}
-          IMAGE: quay.io/ocp-cert/opct
-          QUAY_USER: ${{ secrets.QUAY_USER }}
-          QUAY_PASS: ${{ secrets.QUAY_PASS }}
-        run: |
-          echo "> Logging to Quay.io:"
-          podman login -u="${QUAY_USER}" -p="${QUAY_PASS}" quay.io
-
-          echo "> Build container image:"
-          podman build -t ${IMAGE}:${VERSION} -f hack/Containerfile.ci .
-
-          echo "> Publish container image:"
-          podman push ${IMAGE}:${VERSION}
-
       # https://github.com/mikepenz/release-changelog-builder-action#configuration
       - name: Build Changelog
         id: github_release
@@ -68,3 +52,19 @@ jobs:
           body: |
             ## Changelog
             ${{steps.github_release.outputs.changelog}}
+
+      - name: Build Container and Release to Quay
+        env:
+          VERSION: ${{ steps.get_version.outputs.VERSION }}
+          IMAGE: quay.io/ocp-cert/opct
+          QUAY_USER: ${{ secrets.QUAY_USER }}
+          QUAY_PASS: ${{ secrets.QUAY_PASS }}
+        run: |
+          echo "> Logging to Quay.io:"
+          podman login -u="${QUAY_USER}" -p="${QUAY_PASS}" quay.io
+
+          echo "> Build container image:"
+          podman build -t ${IMAGE}:${VERSION} -f hack/Containerfile.ci .
+
+          echo "> Publish container image:"
+          podman push ${IMAGE}:${VERSION}


### PR DESCRIPTION
https://issues.redhat.com/browse/OPCT-192

The goal of this card is to automatically create the changelog based on the commit standards.

The labels should be defined to fit OPCT project. The existing is suggested, it would be nice to be adapted for the same used by OCP projects