### PR TITLE
OPCT-180: Fix report when plugin is failing on runtime

### DIFF
--- a/pkg/report/cmd.go
+++ b/pkg/report/cmd.go
@@ -271,11 +271,18 @@ func showSummaryPlugin(p *summary.OPCTPluginSummary, bProcessed bool) {
 	}
 	fmt.Printf("   - Failed (Filter CI Flakes): %d\n", len(p.FailedFilterFlaky))
 
-	// rewrite the original status when pass on all filters
+	// checking for runtime failure
+	runtimeFailed := false
+	if p.Total == p.Failed {
+		runtimeFailed = true
+	}
+
+	// rewrite the original status when pass on all filters and not failed on runtime
 	status := p.Status
-	if len(p.FailedFilterFlaky) == 0 {
+	if (len(p.FailedFilterFlaky) == 0) && !runtimeFailed {
 		status = "pass"
 	}
+
 	fmt.Printf("   - Status After Filters     : %s\n", status)
 }
 


### PR DESCRIPTION
https://issues.redhat.com/browse/OPCT-180

The plugin must not pass on `report` when the runtime reported failures.

The runtime fails creating a 'fake' JUnit with failed reason. When there is only one failed test, the plugin evaluation must consider it and ignore any filter.