### PR TITLE
OPCT-191: Removing OCP CI image dependency on build layer

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,7 +45,7 @@ cross-build-darwin-arm64:
 	GOOS=darwin GOARCH=arm64 go build -o openshift-provider-cert-darwin-arm64 $(GO_BUILD_FLAGS)
 
 .PHONY: linux-amd64-container
-linux-amd64-container:
+linux-amd64-container: clean
 	podman build -t $(IMG):latest -f hack/Containerfile --build-arg=RELEASE_TAG=$(RELEASE_TAG) .
 
 .PHONY: test
@@ -56,8 +56,6 @@ test:
 vet:
 	go vet ./...
 
-
 .PHONY: clean
 clean:
-	rm -rf \
-	  openshift-provider-cert
+	rm -rvf ./openshift-provider-cert*

--- a/hack/Containerfile
+++ b/hack/Containerfile
@@ -1,6 +1,7 @@
 
-FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.19-openshift-4.13 AS builder
+FROM docker.io/golang:1.19-alpine AS builder
 ARG RELEASE_TAG
+RUN apk add --no-cache --update make git
 WORKDIR /go/src/github.com/redhat-openshift-ecosystem/provider-certification-tool
 COPY . .
 RUN make linux-amd64 RELEASE_TAG=${RELEASE_TAG}

--- a/hack/Containerfile.ci
+++ b/hack/Containerfile.ci
@@ -6,4 +6,4 @@ LABEL io.k8s.display-name="OPCT" \
 
 COPY ./openshift-provider-cert-linux-amd64 /usr/bin/
 
-CMD ["/usr/bin/opct"]
+CMD ["/usr/bin/openshift-provider-cert-linux-amd64"]


### PR DESCRIPTION
Removing dependency on OCP CI registry images (`registry.ci.openshift.org`) when building the project introduced on https://github.com/redhat-openshift-ecosystem/provider-certification-tool/pull/51 . It would be nice to unblock external contributors to use the tool when need to build it locally.

We don't expect to fall into Docker limitations as that image should be used in a developer environment. 

https://issues.redhat.com/browse/OPCT-191

```
 $ make linux-amd64-container 
podman build -t quay.io/ocp-cert/opct:latest -f hack/Containerfile --build-arg=RELEASE_TAG=0.0.0 .
[1/2] STEP 1/5: FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.19-openshift-4.13 AS builder
Trying to pull registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.19-openshift-4.13...
Error: error creating build container: initializing source docker://registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.19-openshift-4.13: reading manifest rhel-8-golang-1.19-openshift-4.13 in registry.ci.openshift.org/ocp/builder: unauthorized: authentication required
make: *** [Makefile:49: linux-amd64-container] Error 125

```