### PR TITLE
OPCT-177: Documentation fixing sections indentation and formatting 

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,4 +1,4 @@
-# OpenShift Provider Compatibility Tool
+# Home
 
 Welcome to the documentation for the OpenShift Provider Compatibility Tool (OPCT)!
 

--- a/docs/user.md
+++ b/docs/user.md
@@ -176,7 +176,7 @@ Requirements:
 - You have set the dedicated node
 - You have installed OPCT
 
-#### Run the default execution mode (regular) <a name="usage-run-regular"></a>
+#### Run the default execution mode <a name="usage-run-regular"></a>
 
 - Create and run the validation environment (detaching the terminal/background):
 
@@ -184,15 +184,15 @@ Requirements:
 openshift-provider-cert run 
 ```
 
-#### Run the 'upgrade' mode <a name="usage-run-upgrade"></a>
+#### Run the `upgrade` mode <a name="usage-run-upgrade"></a>
 
 The `upgrade` mode runs the OpenShift cluster updates to the `4.y+1` version, then the regular conformance suites will be executed (Kubernetes and OpenShift). This mode was created to validate the entire update process, and to make sure the target OCP release is validated on the conformance suites.
 
 > Note: If you will submit the results to Red Hat Partner Support, you must have Validated the installation on the initial release using the regular execution. For example, to submit the upgrade tests for 4.11->4.12, you must have submitted the regular tests for 4.11. If you have any questions, ask your Red Hat Partner Manager.
 
-Requirements for running 'upgrade' mode:
+Requirements for running the `upgrade` mode:
 
-- You have created the `MachineConfigPool opct`
+- You have created the `MachineConfigPool` with name `opct`
 - You have installed the OpenShift client locally (`oc`) - or have noted the Image `Digest` of the target release
 - You must choose the next release of Y-stream (`4.Y+1`) supported by your current release. (See [update graph](https://access.redhat.com/labs/ocpupgradegraph/update_path))
 
@@ -200,7 +200,7 @@ Requirements for running 'upgrade' mode:
 openshift-provider-cert run --mode=upgrade --upgrade-to-image=$(oc adm release info 4.Y+1.Z -o jsonpath={.image})
 ```
 
-### Run Tests with the Disconnected Mirror registry<a name="usage-run-disconnected"></a>
+#### Run with the Disconnected Mirror registry<a name="usage-run-disconnected"></a>
 
 Tests are able to be run in a disconnected environment through the use of a mirror registry.
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,6 +1,5 @@
-site_name: OpenShift Provider Certification Tool
-site_description: >-
-  OpenShift Provider Certification Tool | Guide
+site_name: OpenShift Provider Compatibility Tool | OPCT
+site_description: OpenShift Provider Compatibility Tool
 site_url: https://redhat-openshift-ecosystem.github.io/provider-certification-tool
 repo_url: https://github.com/redhat-openshift-ecosystem/provider-certification-tool
 edit_uri: edit/main/docs/


### PR DESCRIPTION
Fixes on the User documentation and mkdocs reference for the project name fixed on https://github.com/redhat-openshift-ecosystem/provider-certification-tool/pull/58