### PR TITLE
OPCT-209: bump UBI to fix security issues on container

### DIFF
--- a/hack/Containerfile
+++ b/hack/Containerfile
@@ -6,7 +6,7 @@ WORKDIR /go/src/github.com/redhat-openshift-ecosystem/provider-certification-too
 COPY . .
 RUN make linux-amd64 RELEASE_TAG=${RELEASE_TAG}
 
-FROM registry.access.redhat.com/ubi8/ubi-minimal:8.7-1085.1679482090
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.8-860
 LABEL io.k8s.display-name="OPCT" \
       io.k8s.description="OpenShift/OKD Conformance Tool is designed to run conformance suites to validate custom installations." \
       io.opct.tags="opct,conformance,openshift,tests,e2e" \

--- a/hack/Containerfile.ci
+++ b/hack/Containerfile.ci
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi8/ubi-minimal:8.7-1085.1679482090
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.8-860
 LABEL io.k8s.display-name="OPCT" \
       io.k8s.description="OpenShift/OKD Conformance Tool is designed to run conformance suites to validate custom installations." \
       io.opct.tags="opct,conformance,openshift,tests,e2e" \


### PR DESCRIPTION
Bump UBI to fix security issues before releasing v0.4.

References:

- https://catalog.redhat.com/software/containers/ubi8/ubi-minimal/5c359a62bed8bd75a2c3fba8
- https://issues.redhat.com/browse/OPCT-209
- https://quay.io/repository/ocp-cert/opct?tab=tags

Before:

![Screenshot from 2023-05-17 02-52-47](https://github.com/redhat-openshift-ecosystem/provider-certification-tool/assets/3216894/0b2cb3d5-0b7d-43b8-9113-0a9576fee8dd)

After:

![Screenshot from 2023-05-17 02-55-01](https://github.com/redhat-openshift-ecosystem/provider-certification-tool/assets/3216894/85f35b21-4388-4597-9d38-cf161a9fd325)
