### PR TITLE
OPCT-177: bump plugins image to release v0.4.0

### DIFF
--- a/pkg/types.go
+++ b/pkg/types.go
@@ -13,7 +13,7 @@ const (
 	SonobuoyLabelComponentName     = "component"
 	SonobuoyLabelComponentValue    = "sonobuoy"
 	DefaultToolsRepository         = "quay.io/ocp-cert"
-	PluginsImage                   = "openshift-tests-provider-cert:v0.4.0-alpha1"
+	PluginsImage                   = "openshift-tests-provider-cert:v0.4.0"
 )
 
 var (


### PR DESCRIPTION
Bumping plugin image for v0.4.0 release.

It will be created after all PRs are merged and v0.4.0-rc/beta* has been validated.