### PR TITLE
OPCT-177: pre-release v0.4.0 fixes

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -5,6 +5,10 @@ on:
     tags:
       - '*'
 
+env:
+  CONTAINER_REPO: quay.io/ocp-cert/opct
+  RELEASE_TAG: ${{ github.ref_name }}
+
 jobs:
   release:
     runs-on: ubuntu-latest
@@ -29,8 +33,20 @@ jobs:
 
       - name: Build (all OS)
         run: make all
+
+      - name: Build Container and Release to Quay
         env:
-          RELEASE_TAG: ${{ github.ref_name }}
+          QUAY_USER: ${{ secrets.QUAY_USER }}
+          QUAY_PASS: ${{ secrets.QUAY_PASS }}
+        run: |
+          echo "> Logging to Quay.io:"
+          podman login -u="${QUAY_USER}" -p="${QUAY_PASS}" quay.io
+
+          echo "> Build container image:"
+          podman build -t ${CONTAINER_REPO}:${RELEASE_TAG} -f hack/Containerfile.ci .
+
+          echo "> Publish container image:"
+          podman push ${CONTAINER_REPO}:${RELEASE_TAG}
 
       # https://github.com/mikepenz/release-changelog-builder-action#configuration
       - name: Build Changelog
@@ -52,19 +68,6 @@ jobs:
           body: |
             ## Changelog
             ${{steps.github_release.outputs.changelog}}
-
-      - name: Build Container and Release to Quay
-        env:
-          VERSION: ${{ steps.get_version.outputs.VERSION }}
-          IMAGE: quay.io/ocp-cert/opct
-          QUAY_USER: ${{ secrets.QUAY_USER }}
-          QUAY_PASS: ${{ secrets.QUAY_PASS }}
-        run: |
-          echo "> Logging to Quay.io:"
-          podman login -u="${QUAY_USER}" -p="${QUAY_PASS}" quay.io
-
-          echo "> Build container image:"
-          podman build -t ${IMAGE}:${VERSION} -f hack/Containerfile.ci .
-
-          echo "> Publish container image:"
-          podman push ${IMAGE}:${VERSION}
+            
+            ## Container Images
+            - [${CONTAINER_REPO}:${RELEASE_TAG}](https://quay.io/repository/ocp-cert/opct?tab=tags)

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -64,7 +64,8 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           files: |
-            openshift-provider-cert*
+            openshift-provider-cert-*
+            opct-*
           body: |
             ## Changelog
             ${{steps.github_release.outputs.changelog}}

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 openshift-provider-cert-*
+opct-*
 kubeconfig
 .idea/
 

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ GO_BUILD_FLAGS := -ldflags '-s -w -X github.com/redhat-openshift-ecosystem/provi
 unexport GOFLAGS
 
 .PHONY: all
-all: linux-amd64 linux-amd64-container cross-build-windows-amd64 cross-build-darwin-amd64 cross-build-darwin-arm64
+all: linux-amd64-container cross-build-windows-amd64 cross-build-darwin-amd64 cross-build-darwin-arm64
 
 .PHONY: build
 build:
@@ -31,21 +31,25 @@ verify-codegen:
 .PHONY: linux-amd64
 linux-amd64:
 	GOOS=linux GOARCH=amd64 go build -o openshift-provider-cert-linux-amd64 $(GO_BUILD_FLAGS)
+	cp openshift-provider-cert-linux-amd64 opct-linux-amd64
 
 .PHONY: cross-build-windows-amd64
 cross-build-windows-amd64:
 	GOOS=windows GOARCH=amd64 go build -o openshift-provider-cert-windows.exe $(GO_BUILD_FLAGS)
+	cp openshift-provider-cert-windows.exe opct-windows.exe
 
 .PHONY: cross-build-darwin-amd64
 cross-build-darwin-amd64:
 	GOOS=darwin GOARCH=amd64 go build -o openshift-provider-cert-darwin-amd64 $(GO_BUILD_FLAGS)
+	cp openshift-provider-cert-darwin-amd64 opct-darwin-amd64
 
 .PHONY: cross-build-darwin-arm64
 cross-build-darwin-arm64:
 	GOOS=darwin GOARCH=arm64 go build -o openshift-provider-cert-darwin-arm64 $(GO_BUILD_FLAGS)
+	cp openshift-provider-cert-darwin-arm64 opct-darwin-arm64
 
 .PHONY: linux-amd64-container
-linux-amd64-container: clean
+linux-amd64-container: linux-amd64
 	podman build -t $(IMG):latest -f hack/Containerfile --build-arg=RELEASE_TAG=$(RELEASE_TAG) .
 
 .PHONY: test
@@ -58,4 +62,4 @@ vet:
 
 .PHONY: clean
 clean:
-	rm -rvf ./openshift-provider-cert*
+	rm -rvf ./openshift-provider-cert-* ./opct-*

--- a/docs/dev.md
+++ b/docs/dev.md
@@ -50,9 +50,32 @@ Release process checklist:
         - artifacts collected
         - results are under regular [CI executions](https://openshift-provider-certification.s3.us-west-2.amazonaws.com/index.html)
 - Create a tag on [Plugins repository](https://github.com/redhat-openshift-ecosystem/provider-certification-plugins) based on the `main` branch (or the commit for the release);
+~~~bash
+# Example
+git tag v0.4.0 -m "Release for OPCT v0.4 related to features on OPCT-XXX"
+git push --tags upstream
+~~~
 - Open a PR updating the [`PluginsImage` value](https://github.com/redhat-openshift-ecosystem/provider-certification-tool/blob/main/pkg/types.go#LL16C2-L16C14) on the CLI repository, merge it;
 - Create a tag on [CLI/Tool repository](https://github.com/redhat-openshift-ecosystem/provider-certification-tool) based on the `main` branch (or the commit for the release)
+~~~bash
+# Example
+git tag v0.4.0 -m "Release for OPCT v0.4 related to features on OPCT-XXX"
+git push --tags upstream
+~~~
 
+### Manual tests
+
+- Create an OCP cluster
+- Prepare the cluster to run OPCT: set tests label for dedicated node, taint, create registry, create MachineConfigPool for upgrade, wait to be ready, etc
+    - It's possible to use the Ansible Playbook to do everything in Day-2 by running (WIP on [#38](https://github.com/redhat-openshift-ecosystem/provider-certification-tool/pull/38)):
+```bash
+ansible-playbook hack/opct-runner/opct-run-tool-preflight.yaml  -e cluster_name=opct-v040
+```
+- Run the tool
+```bash
+./opct-linux-amd64 run -w --plugins-image=openshift-tests-provider-cert:v0.4.0-beta2
+```
+- Collect the results and compare with old releases. Baseline CI artifacts is available [here](https://openshift-provider-certification.s3.us-west-2.amazonaws.com/index.html).
 
 ## Development Notes <a name="dev-notes"></a>
 

--- a/pkg/assets/bindata.go
+++ b/pkg/assets/bindata.go
@@ -63,7 +63,7 @@ var _manifestsOpenshiftArtifactsCollectorYaml = []byte(`podSpec:
       emptyDir: {}
   containers:
     - name: report-progress
-      image: "{{ .ToolsImage }}"
+      image: "{{ .PluginsImage }}"
       imagePullPolicy: Always
       priorityClassName: system-node-critical
       command: ["./report-progress.sh"]
@@ -96,7 +96,7 @@ sonobuoy-config:
   skipCleanup: true
 spec:
   name: plugin
-  image: "{{ .ToolsImage }}"
+  image: "{{ .PluginsImage }}"
   imagePullPolicy: Always
   volumeMounts:
   - mountPath: /tmp/sonobuoy/results
@@ -160,7 +160,7 @@ var _manifestsOpenshiftClusterUpgradeYaml = []byte(`podSpec:
       emptyDir: {}
   containers:
     - name: report-progress
-      image: "{{ .ToolsImage }}"
+      image: "{{ .PluginsImage }}"
       imagePullPolicy: Always
       priorityClassName: system-node-critical
       command: ["./report-progress.sh"]
@@ -193,7 +193,7 @@ sonobuoy-config:
   skipCleanup: true
 spec:
   name: plugin
-  image: "{{ .ToolsImage }}"
+  image: "{{ .PluginsImage }}"
   imagePullPolicy: Always
   priorityClassName: system-node-critical
   volumeMounts:
@@ -258,7 +258,7 @@ var _manifestsOpenshiftConformanceValidatedYaml = []byte(`podSpec:
       emptyDir: {}
   containers:
     - name: report-progress
-      image: "{{ .ToolsImage }}"
+      image: "{{ .PluginsImage }}"
       imagePullPolicy: Always
       priorityClassName: system-node-critical
       command: ["./report-progress.sh"]
@@ -291,7 +291,7 @@ sonobuoy-config:
   skipCleanup: true
 spec:
   name: plugin
-  image: "{{ .ToolsImage }}"
+  image: "{{ .PluginsImage }}"
   imagePullPolicy: Always
   priorityClassName: system-node-critical
   volumeMounts:
@@ -355,7 +355,7 @@ var _manifestsOpenshiftKubeConformanceYaml = []byte(`podSpec:
       emptyDir: {}
   containers:
     - name: report-progress
-      image: "{{ .ToolsImage }}"
+      image: "{{ .PluginsImage }}"
       imagePullPolicy: Always
       priorityClassName: system-node-critical
       command: ["./report-progress.sh"]
@@ -388,7 +388,7 @@ sonobuoy-config:
   skipCleanup: true
 spec:
   name: plugin
-  image: "{{ .ToolsImage }}"
+  image: "{{ .PluginsImage }}"
   imagePullPolicy: Always
   priorityClassName: system-node-critical
   volumeMounts:


### PR DESCRIPTION
- Fix unbound variables on the CI step when creating release v0.4: https://github.com/redhat-openshift-ecosystem/provider-certification-tool/actions/runs/5047592402/jobs/9054669579
- Reorder the container build step to make sure it will succeed before creating the release, otherwise, the workflow should fail
- copy and ship binaries with the prefix `opct-*` (s/openshift-provider-cert/opct/) to deprecate the cert name in future releases
- update static files crashing when processing the tool with renamed argument `plugins-image` (missing on https://github.com/redhat-openshift-ecosystem/provider-certification-tool/pull/66 )
- add dev doc expanding the release process with more information about manual tests 