### PR TITLE
OPCT-199: CI - added linter job and update workflow dependencies

### DIFF
--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -10,52 +10,59 @@ on:
       - '*'
 
 jobs:
-  # TODO: add go-lint
-  go-test:
-    name: "go-test"
+  go-lint:
+    name: go-lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - name: Set up Go
-        uses: actions/setup-go@v2
+      - uses: actions/checkout@v3
+      - uses: actions/setup-go@v4
         with:
-          go-version: 1.19
-
-      - name: Run unit tests
-        run: make test
-
-      - name: Run go vet
-        run: make vet
-
-      - name: Run static code analysis
-        uses: dominikh/staticcheck-action@v1.3.0
+          go-version: '1.19'
+          cache: false
+      # https://github.com/golangci/golangci-lint-action
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v3
         with:
-          version: "2022.1.3"
-
-  go-vet:
-    name: "go-vet"
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - name: Set up Go
-        uses: actions/setup-go@v2
-        with:
-          go-version: 1.19
-
-      - name: Run go vet
-        run: make vet
+          version: v1.53
+          args: --timeout=10m
 
   go-static:
     name: "go-staticcheck"
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - name: Set up Go
-        uses: actions/setup-go@v2
+      - uses: actions/checkout@v3
+      - uses: actions/setup-go@v4
         with:
-          go-version: 1.19
-
+          go-version: '1.19'
       - name: Run static code analysis
         uses: dominikh/staticcheck-action@v1.3.0
         with:
           version: "2022.1.3"
+
+  go-test:
+    name: go-test
+    runs-on: ubuntu-latest
+    needs:
+    - go-lint
+    - go-static
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-go@v4
+        with:
+          go-version: '1.19'
+      - name: Run unit tests
+        run: make test
+
+  go-vet:
+    name: "go-vet"
+    runs-on: ubuntu-latest
+    needs:
+    - go-lint
+    - go-static
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-go@v4
+        with:
+          go-version: '1.19'
+      - name: Run go vet
+        run: make vet

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -50,13 +50,20 @@ func Execute() {
 	}
 }
 
+func initBindFlag(flag string) {
+	err := viper.BindPFlag(flag, rootCmd.PersistentFlags().Lookup(flag))
+	if err != nil {
+		log.Warnf("Unable to bind flag %s\n", flag)
+	}
+}
+
 func init() {
 	cobra.OnInitialize(initConfig)
 
 	rootCmd.PersistentFlags().String("kubeconfig", "", "kubeconfig for target OpenShift cluster")
 	rootCmd.PersistentFlags().String("loglevel", "info", "logging level")
-	viper.BindPFlag("kubeconfig", rootCmd.PersistentFlags().Lookup("kubeconfig"))
-	viper.BindPFlag("loglevel", rootCmd.PersistentFlags().Lookup("loglevel"))
+	initBindFlag("kubeconfig")
+	initBindFlag("loglevel")
 
 	// Link in child commands
 	rootCmd.AddCommand(destroy.NewCmdDestroy())

--- a/internal/pkg/summary/consolidated.go
+++ b/internal/pkg/summary/consolidated.go
@@ -530,7 +530,7 @@ func createSheet(sheet *excelize.File, sheeName string) error {
 
 	// create header
 	for k, v := range header {
-		sheet.SetCellValue(sheeName, k, v)
+		_ = sheet.SetCellValue(sheeName, k, v)
 	}
 
 	return nil
@@ -539,12 +539,12 @@ func createSheet(sheet *excelize.File, sheeName string) error {
 // populateGsheet fill each row per error item.
 func populateSheet(sheet *excelize.File, sheeName, suite string, list []string, rowN *int64) {
 	for idx, v := range list {
-		sheet.SetCellValue(sheeName, fmt.Sprintf("A%d", *rowN), suite)
-		sheet.SetCellValue(sheeName, fmt.Sprintf("B%d", *rowN), idx+1)
-		sheet.SetCellValue(sheeName, fmt.Sprintf("C%d", *rowN), sheeName)
-		sheet.SetCellValue(sheeName, fmt.Sprintf("D%d", *rowN), v)
-		sheet.SetCellValue(sheeName, fmt.Sprintf("E%d", *rowN), "TODO Review")
-		sheet.SetCellValue(sheeName, fmt.Sprintf("F%d", *rowN), "")
+		_ = sheet.SetCellValue(sheeName, fmt.Sprintf("A%d", *rowN), suite)
+		_ = sheet.SetCellValue(sheeName, fmt.Sprintf("B%d", *rowN), idx+1)
+		_ = sheet.SetCellValue(sheeName, fmt.Sprintf("C%d", *rowN), sheeName)
+		_ = sheet.SetCellValue(sheeName, fmt.Sprintf("D%d", *rowN), v)
+		_ = sheet.SetCellValue(sheeName, fmt.Sprintf("E%d", *rowN), "TODO Review")
+		_ = sheet.SetCellValue(sheeName, fmt.Sprintf("F%d", *rowN), "")
 		*(rowN) += 1
 	}
 }

--- a/pkg/report/cmd.go
+++ b/pkg/report/cmd.go
@@ -39,7 +39,7 @@ func NewCmdReport() *cobra.Command {
 		&data.archiveBase, "baseline", "b", "",
 		"Baseline result archive file. Example: -b file.tar.gz",
 	)
-	cmd.MarkFlagRequired("base")
+	_ = cmd.MarkFlagRequired("base")
 
 	cmd.Flags().StringVarP(
 		&data.saveTo, "save-to", "s", "",

--- a/pkg/run/run.go
+++ b/pkg/run/run.go
@@ -62,6 +62,13 @@ func newRunOptions() *RunOptions {
 	}
 }
 
+func hideOptionalFlags(cmd *cobra.Command, flag string) {
+	err := cmd.Flags().MarkHidden(flag)
+	if err != nil {
+		log.Debugf("Unable to hide flag %s: %v", flag, err)
+	}
+}
+
 func NewCmdRun() *cobra.Command {
 	var err error
 	var kclient kubernetes.Interface
@@ -97,7 +104,7 @@ func NewCmdRun() *cobra.Command {
 			log.Info("Jobs scheduled! Waiting for resources be created...")
 
 			// Wait for Sonobuoy to create
-			wait.WaitForRequiredResources(kclient)
+			err = wait.WaitForRequiredResources(kclient)
 			if err != nil {
 				log.WithError(err).Fatal("error waiting for sonobuoy pods to become ready")
 			}
@@ -138,10 +145,10 @@ func NewCmdRun() *cobra.Command {
 	cmd.Flags().IntVar(&o.timeout, "timeout", defaultRunTimeoutSeconds, "Execution timeout in seconds")
 	cmd.Flags().BoolVarP(&o.watch, "watch", "w", defaultRunWatchFlag, "Keep watch status after running")
 
-	// Hide dedicated flag since this is for development only
-	cmd.Flags().MarkHidden("dedicated")
-	cmd.Flags().MarkHidden("dev-count")
-	cmd.Flags().MarkHidden("plugins-image")
+	// Hide optional flags
+	hideOptionalFlags(cmd, "dedicated")
+	hideOptionalFlags(cmd, "dev-count")
+	hideOptionalFlags(cmd, "plugins-image")
 
 	return cmd
 }

--- a/pkg/status/printer_test.go
+++ b/pkg/status/printer_test.go
@@ -38,5 +38,5 @@ func Test_PrintStatus(t *testing.T) {
 		return
 	}
 
-	tmpl.Execute(os.Stderr, ps)
+	_ = tmpl.Execute(os.Stderr, ps)
 }


### PR DESCRIPTION
Create CI improvements identified in https://github.com/redhat-openshift-ecosystem/provider-certification-tool/pull/73 (quick win):

- Remove duplicated steps in the job
- Add linter job
- Create job chain, requiring [linter and static check] to run [tests and vet]