### PR TITLE
OPCT-239: Fix CI step forcing to fetch tags to generate changelog file

### DIFF
--- a/.github/workflows/static-website.yml
+++ b/.github/workflows/static-website.yml
@@ -27,7 +27,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
+        with:
+          fetch-tags: true
 
       - name: Build mkdocs website
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,9 @@ opct-*
 kubeconfig
 .idea/
 
+# build files
 dist/
+
+# changelog is generated automaticaly by hack/generate-changelog.sh
+# available only in the rendered webpage (built by mkdocs).
+docs/CHANGELOG.md

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,1 +1,0 @@
-.gitkeep

--- a/hack/generate-changelog.sh
+++ b/hack/generate-changelog.sh
@@ -18,31 +18,34 @@ chagelog_dir="$(dirname $0)"/../docs/changelogs
 chagelog_dir="/tmp/opct-changelogs"
 mkdir -p $chagelog_dir
 
-cat > "$chagelog_file" << EOF
+# Phase 0: prepare the environment
+## Clone plugins repository
 
-# CHANGELOG
-
-EOF
+## Phase I: Create changelog fragment files under {changelog_dir}/{release}.md,
 
 first_commit=$(git rev-list --max-parents=0 HEAD)
 init_release=$first_commit
-for rel in ${releases[*]}; do
+for rel in "${releases[@]}"; do
     ch_file=$chagelog_dir/$rel.md
-    echo -e "\n# [$rel](https://github.com/redhat-openshift-ecosystem/provider-certification-tool/releases/tag/$rel)" > "$ch_file"
-    echo -e "OPCT:\n" >> "$ch_file"
-    git log --pretty=oneline --abbrev-commit --no-decorate --no-color $init_release..tags/$rel | \
-    while read line
+    echo -e "\n## [$rel](https://github.com/redhat-openshift-ecosystem/provider-certification-tool/releases/tag/$rel)" > "$ch_file"
+    echo -e "\n### OPCT\n" >> "$ch_file"
+
+    # read the git log with changes between releases (from/to)
+    git log --pretty=oneline --abbrev-commit --no-decorate --no-color "$init_release"..tags/"$rel" | \
+    while read -r line
     do
-        commit="$(echo $line | awk '{print$1}')"
+        commit="$(echo "$line" | awk '{print$1}')"
         commit_url="[$commit](https://github.com/redhat-openshift-ecosystem/provider-certification-tool/commit/$commit)"
         line="${line#"$commit"}"
-        jira_card=$(echo $line | grep -Po '(OPCT-\d+)' || true)
+        jira_card=$(echo "$line" | grep -Po '(OPCT-\d+)' || true)
         if [ -n "${jira_card-}" ] ; then
-            line=$(echo $line | sed "s/$jira_card/\[$jira_card\]\(https\:\/\/issues.redhat.com\/browse\/$jira_card\)/")
+            line=$(echo "$line" | sed "s/$jira_card/\[$jira_card\]\(https\:\/\/issues.redhat.com\/browse\/$jira_card\)/")
         fi
-        pr_id=$(echo $line | grep -Po '#\d+' || true)
+
+        # lookup for PR number (#{\d+}) in the commit name
+        pr_id=$(echo "$line" | grep -Po '#\d+' || true)
         if [ -n "${pr_id-}" ] ; then
-            line=$(echo $line | sed "s/$pr_id/\[$pr_id\]\(https\:\/\/github.com\/redhat-openshift-ecosystem\/provider-certification-tool\/pull\/${pr_id#\#}\)/")
+            line=$(echo "$line" | sed "s/$pr_id/\[$pr_id\]\(https\:\/\/github.com\/redhat-openshift-ecosystem\/provider-certification-tool\/pull\/${pr_id#\#}\)/")
         fi
         echo -e "- $commit_url - ${line}" >> "$ch_file"
     done
@@ -50,12 +53,16 @@ for rel in ${releases[*]}; do
     echo -e "\n\n" >> "$ch_file"
 done
 
+## Phase II: create devel.md markdown file with the changes since the last release.
+
 # devel (since last release - need to run from 'main' branch)
 ch_file=$chagelog_dir/devel.md
-echo -e "\n# Development\n" > "$ch_file"
-echo -e "OPCT:\n" >> "$ch_file"
-git log --pretty=oneline --abbrev-commit --no-decorate --no-color $init_release..HEAD | \
-while read line
+echo -e "\n## Development\n" > "$ch_file"
+echo -e "### OPCT\n" >> "$ch_file"
+
+# Process OPCT repo
+git log --pretty=oneline --abbrev-commit --no-decorate --no-color "$init_release"..HEAD | \
+while read -r line
 do
     commit="$(echo $line | awk '{print$1}')"
     commit_url="[$commit](https://github.com/redhat-openshift-ecosystem/provider-certification-tool/commit/$commit)"
@@ -71,16 +78,23 @@ do
     echo -e "- $commit_url - ${line}" >> "$ch_file"
 done
 
+# Phase III: aggregate all generated markdown files into a single CHANGELOG.md ({chagelog_file})
+
 cat > "$chagelog_file" << EOF
 
 # CHANGELOG
 
+Changelog by release for CLI (OPCT) and Plugins repositories.
+
 EOF
 
+# devel.md will be first
 cat $chagelog_dir/devel.md >> "$chagelog_file"
+
+# then append the releases by reverse order (newest version/file first)
 for rev_releases in $(ls -r $chagelog_dir --ignore=devel.md); do
     echo -e "\n" >> "$chagelog_file"
-    cat $chagelog_dir/$rev_releases >> "$chagelog_file"
+    cat $chagelog_dir/"$rev_releases" >> "$chagelog_file"
 done
 
 echo -e "\n\n > This page is generated automatically by CI/hack-generate-changelog.sh\n\n" >> "$chagelog_file"


### PR DESCRIPTION
Fixes #74 :
- the CHANGELOG.md is generated by CI and available only in the rendered page. If we decide to keep it versioned, we can add it in the future. For now it is generated automatically
- force CI step/action to fetch tags to run correctly the changelog generator
- nits shell script