### PR TITLE
OPCT-213: backport plugins to support OCP 4.14 on v0.4

### DIFF
--- a/pkg/types.go
+++ b/pkg/types.go
@@ -13,7 +13,7 @@ const (
 	SonobuoyLabelComponentName     = "component"
 	SonobuoyLabelComponentValue    = "sonobuoy"
 	DefaultToolsRepository         = "quay.io/ocp-cert"
-	PluginsImage                   = "openshift-tests-provider-cert:v0.4.0"
+	PluginsImage                   = "openshift-tests-provider-cert:v0.4.1"
 )
 
 var (


### PR DESCRIPTION
Update base plugin image to support OCP 4.14.

This is a backport of https://github.com/redhat-openshift-ecosystem/provider-certification-plugins/pull/43 bumping to plugins image plugin backport https://github.com/redhat-openshift-ecosystem/provider-certification-plugins/pull/47 (required to be merged).

The v0.5 will cover that patch, but that release is still blocked by #76 

- [x] Waiting for https://github.com/redhat-openshift-ecosystem/provider-certification-plugins/pull/47 to merge
- [x] Create tag for plugins v0.4.1:
https://github.com/redhat-openshift-ecosystem/provider-certification-plugins/releases/tag/v0.4.1
https://quay.io/repository/ocp-cert/openshift-tests-provider-cert?tab=tags
- [ ] Create tag for CLI v0.4.1(after this merged)