### PR TITLE
OPCT-226: Added check rules for etcd

### DIFF
--- a/docs/review/rules.md
+++ b/docs/review/rules.md
@@ -221,7 +221,7 @@ References:
 ### OPCT-011 <a name="OPCT-011"></a>
 
 - **Name**: etcd logs: slow requests: maximum should be under 1000ms
-- **Description**: etcd logs are reporting slow requests with average above 1000 milisseconds.
+- **Description**: etcd logs are reporting slow requests with maximum above 1000 milisseconds.
 - **Action**: Review if the storage volume for control plane nodes, or dedicated volume for etcd, has the required performance to run etcd in production environment.
 - **Troubleshooting**:
 


### PR DESCRIPTION
Introducing etcd check rules based in the parsed logs for etcd (etcd request took too long).

The acceptance values are calibrated from the baseline providers:

- AWS (ocp414rc0_AWS_None_202309222127_sonobuoy_47efe9ef-06e4-48f3-a190-4e3523ff1ae0.tar.gz)

![Screenshot from 2023-09-25 13-41-29](https://github.com/redhat-openshift-ecosystem/provider-certification-tool/assets/3216894/1291fe8f-e0c9-41bc-9c99-82c543ab3e5f)

- AWS (4.13.9-20230925-HighlyAvailable-aws-None-202309250459_sonobuoy_f4e06587-e7b3-4cbd-bcf4-d1350ec35d9a.tar.gz):

![Screenshot from 2023-09-25 13-38-17](https://github.com/redhat-openshift-ecosystem/provider-certification-tool/assets/3216894/25027448-f141-448d-b6eb-f8932ff002d8)

- vSphere (4.13.9-20230821-HighlyAvailable-vsphere-None.tar.gz):

![Screenshot from 2023-09-25 13-34-52](https://github.com/redhat-openshift-ecosystem/provider-certification-tool/assets/3216894/d1d43dbb-31fd-40d9-a487-fc6a5d213a9f)

The check rules is implemented in the feature https://github.com/redhat-openshift-ecosystem/provider-certification-tool/pull/76 
https://github.com/redhat-openshift-ecosystem/provider-certification-tool/blob/dc2156317dfc92b47c582b494fef47876337d94b/internal/opct/report/checks.go#L321-L388