### PR TITLE
OPCT-252: fixes/ci empty sum file when building windows

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,7 @@ IMG ?= quay.io/ocp-cert/opct
 VERSION=$(shell git rev-parse --short HEAD)
 RELEASE_TAG ?= 0.0.0
 BIN_NAME ?= opct
+BIN_EXT ?= ''
 
 GO_BUILD_FLAGS := -ldflags '-s -w -X github.com/redhat-openshift-ecosystem/provider-certification-tool/pkg/version.commit=$(VERSION) -X github.com/redhat-openshift-ecosystem/provider-certification-tool/pkg/version.version=$(RELEASE_TAG)'
 GOOS ?= linux
@@ -29,8 +30,8 @@ build-dep:
 
 .PHONY: build
 build: build-dep
-	GOOS=$(GOOS) GOARCH=$(GOARCH) go build -o $(BUILD_DIR)/opct-$(GOOS)-$(GOARCH)$(GOEXT) $(GO_BUILD_FLAGS)
-	@cd $(BUILD_DIR); md5sum $(BUILD_DIR)/opct-$(GOOS)-$(GOARCH)$(GOEXT) > $(BUILD_DIR)/opct-$(GOOS)-$(GOARCH)$(GOEXT).sum; cd -
+	GOOS=$(GOOS) GOARCH=$(GOARCH) go build -o $(BUILD_DIR)/opct-$(GOOS)-$(GOARCH)$(BIN_EXT) $(GO_BUILD_FLAGS)
+	@cd $(BUILD_DIR); md5sum $(BUILD_DIR)/opct-$(GOOS)-$(GOARCH)$(BIN_EXT) > $(BUILD_DIR)/opct-$(GOOS)-$(GOARCH)$(BIN_EXT).sum; cd -
 
 .PHONY: build-linux-amd64
 build-linux-amd64: GOOS = linux
@@ -40,7 +41,7 @@ build-linux-amd64: build
 .PHONY: build-windows-amd64
 build-windows-amd64: GOOS = windows
 build-windows-amd64: GOARCH = amd64
-build-windows-amd64: GOEXT = .exe
+build-windows-amd64: BIN_EXT = .exe
 build-windows-amd64: build
 
 .PHONY: build-darwin-amd64


### PR DESCRIPTION
Fixes:
- https://issues.redhat.com/browse/OPCT-252
- https://github.com/redhat-openshift-ecosystem/provider-certification-tool/actions/runs/6308746341/job/17127412515