### PR TITLE
OPCT-226: cmd/status: Adding flag to set the watch interval

### DIFF
--- a/pkg/retrieve/retrieve.go
+++ b/pkg/retrieve/retrieve.go
@@ -48,7 +48,7 @@ func NewCmdRetrieve() *cobra.Command {
 				return
 			}
 
-			s := status.NewStatusOptions(false)
+			s := status.NewStatusOptions(&status.StatusInput{Watch: false})
 			err = s.PreRunCheck(kclient)
 			if err != nil {
 				log.Error(err)

--- a/pkg/run/run.go
+++ b/pkg/run/run.go
@@ -40,12 +40,13 @@ type RunOptions struct {
 	// PluginsImage
 	// defines the image containing plugins associated with the provider-certification-tool.
 	// this variable is referenced by plugin manifest templates to dynamically reference the plugins image.
-	PluginsImage string
-	timeout      int
-	watch        bool
-	devCount     string
-	mode         string
-	upgradeImage string
+	PluginsImage  string
+	timeout       int
+	watch         bool
+	watchInterval int
+	devCount      string
+	mode          string
+	upgradeImage  string
 }
 
 const (
@@ -110,9 +111,9 @@ func NewCmdRun() *cobra.Command {
 			}
 
 			// Sleep to give status time to appear
-			time.Sleep(status.StatusInterval)
+			s := status.NewStatusOptions(&status.StatusInput{Watch: o.watch, IntervalSeconds: o.watchInterval})
+			time.Sleep(s.GetIntervalSeconds())
 
-			s := status.NewStatusOptions(o.watch)
 			err = s.WaitForStatusReport(cmd.Context(), sclient)
 			if err != nil {
 				log.WithError(err).Fatal("error retrieving aggregator status")
@@ -144,6 +145,7 @@ func NewCmdRun() *cobra.Command {
 	cmd.Flags().StringVar(&o.imageRepository, "image-repository", "", "Image repository containing required images test environment. Example: openshift-provider-cert-tool --mirror-repository mirror.repository.net/ocp-cert")
 	cmd.Flags().IntVar(&o.timeout, "timeout", defaultRunTimeoutSeconds, "Execution timeout in seconds")
 	cmd.Flags().BoolVarP(&o.watch, "watch", "w", defaultRunWatchFlag, "Keep watch status after running")
+	cmd.Flags().IntVarP(&o.watchInterval, "watch-interval", "", status.DefaultStatusIntervalSeconds, "Interval to watch the status and print in the stdout")
 
 	// Hide optional flags
 	hideOptionalFlags(cmd, "dedicated")


### PR DESCRIPTION
The interval watching, and printing in the stdout is not customized leading to a high amount of messages in the stdout - it is good for troubleshooting purpose, but a downside is it increases the amount of logs stored in CI with actionable information.

This PR introduces a possibility to set the flag `--watch-interval=int` to the `status` command, also called by the `run` command.

This change is isolated from the `report` enhancement covered in #76 