### PR TITLE
OPCT-257: improve error handler when using the client as api pkg

### DIFF
--- a/pkg/destroy/destroy.go
+++ b/pkg/destroy/destroy.go
@@ -34,14 +34,14 @@ func NewCmdDestroy() *cobra.Command {
 		Aliases: []string{"delete"},
 		Short:   "Destroy current validation environment",
 		Long:    `Destroys resources used for conformance testing inside of the target OpenShift cluster. This will not destroy OpenShift cluster.`,
-		Run: func(cmd *cobra.Command, args []string) {
+		RunE: func(cmd *cobra.Command, args []string) error {
 			log.Info("Starting the destroy flow...")
 
 			// Client setup
 			kclient, sclient, err := client.CreateClients()
 			if err != nil {
 				log.Error(err)
-				return
+				return err
 			}
 
 			err = o.DeleteSonobuoyEnv(sclient)
@@ -62,6 +62,7 @@ func NewCmdDestroy() *cobra.Command {
 			}
 
 			log.Info("Destroy done!")
+			return nil
 		},
 	}
 

--- a/pkg/retrieve/retrieve.go
+++ b/pkg/retrieve/retrieve.go
@@ -1,6 +1,7 @@
 package retrieve
 
 import (
+	"fmt"
 	"io"
 	"os"
 	"time"
@@ -23,46 +24,41 @@ func NewCmdRetrieve() *cobra.Command {
 		Args:  cobra.MaximumNArgs(1),
 		Short: "Collect results from validation environment",
 		Long:  `Downloads the results archive from the validation environment`,
-		Run: func(cmd *cobra.Command, args []string) {
+		RunE: func(cmd *cobra.Command, args []string) error {
 			destinationDirectory, err := os.Getwd()
 			if err != nil {
-				log.Error(err)
-				return
+				return fmt.Errorf("retrieve finished with errors: %v", err)
 			}
 			if len(args) == 1 {
 				destinationDirectory = args[0]
 				finfo, err := os.Stat(destinationDirectory)
 				if err != nil {
-					log.Error(err)
-					return
+					return fmt.Errorf("retrieve finished with errors: %v", err)
 				}
 				if !finfo.IsDir() {
-					log.Error("Retrieval destination must be directory")
-					return
+					return fmt.Errorf("retrieve finished with errors: %v", err)
 				}
 			}
 
 			kclient, sclient, err := client.CreateClients()
 			if err != nil {
-				log.Error(err)
-				return
+				return fmt.Errorf("retrieve finished with errors: %v", err)
 			}
 
 			s := status.NewStatusOptions(&status.StatusInput{Watch: false})
 			err = s.PreRunCheck(kclient)
 			if err != nil {
-				log.Error(err)
-				return
+				return fmt.Errorf("retrieve finished with errors: %v", err)
 			}
 
 			log.Info("Collecting results...")
 
 			if err := retrieveResultsRetry(sclient, destinationDirectory); err != nil {
-				log.Error(err)
-				return
+				return fmt.Errorf("retrieve finished with errors: %v", err)
 			}
 
 			log.Info("Use the results command to check the validation test summary or share the results archive with your Red Hat partner.")
+			return nil
 		},
 	}
 }

--- a/pkg/status/status.go
+++ b/pkg/status/status.go
@@ -63,40 +63,41 @@ func NewCmdStatus() *cobra.Command {
 		Use:   "status",
 		Short: "Show the current status of the validation tool",
 		Long:  ``,
-		Run: func(cmd *cobra.Command, args []string) {
+		RunE: func(cmd *cobra.Command, args []string) error {
 			// Client setup
 			kclient, sclient, err := client.CreateClients()
 			if err != nil {
-				log.Error(err)
-				return
+				log.WithError(err).Errorf("status finished with errors: %v", err)
+				return err
 			}
 
 			// Pre-checks and setup
 			err = o.PreRunCheck(kclient)
 			if err != nil {
 				log.WithError(err).Error("error running pre-checks")
-				return
+				return err
 			}
 
 			// Wait for Sonobuoy to create
 			err = wait.WaitForRequiredResources(kclient)
 			if err != nil {
 				log.WithError(err).Error("error waiting for sonobuoy pods to become ready")
-				return
+				return err
 			}
 
 			// Wait for Sononbuoy to start reporting status
 			err = o.WaitForStatusReport(cmd.Context(), sclient)
 			if err != nil {
 				log.WithError(err).Error("error retrieving current aggregator status")
-				return
+				return err
 			}
 
 			err = o.Print(cmd, sclient)
 			if err != nil {
 				log.WithError(err).Error("error printing status")
-				return
+				return err
 			}
+			return nil
 		},
 	}
 


### PR DESCRIPTION
- Fix error handler across different parts of the code, preventing fatal when not needed, raising to CLI handle the error message/code.
- Kubeconfig env var wasn't well evaluated when using the `pkg/client/client.go` as API, adjusting to make precedence of env variable