### PR TITLE
OPCT-257: CI pipeline fix when uploading artifacts to release

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -67,12 +67,21 @@ jobs:
         uses: softprops/action-gh-release@v0.1.15
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          CONTAINER_REPO: ${{ env.CONTAINER_REPO }}
+          RELEASE_TAG: ${{ env.RELEASE_TAG }}
         with:
           files: |
-            build/opct-*
+            build/opct-darwin-amd64
+            build/opct-darwin-amd64.sum
+            build/opct-darwin-arm64
+            build/opct-darwin-arm64.sum
+            build/opct-linux-amd64
+            build/opct-linux-amd64.sum
+            build/opct-windows-amd64.exe
+            build/opct-windows-amd64.exe.sum
           body: |
             ## Changelog
             ${{steps.github_release.outputs.changelog}}
             
             ## Container Images
-            - [${CONTAINER_REPO}:${RELEASE_TAG}](https://quay.io/repository/ocp-cert/opct?tab=tags)
+            - [${{ env.CONTAINER_REPO }}:${{ env.RELEASE_TAG }}](https://quay.io/repository/ocp-cert/opct?tab=tags)


### PR DESCRIPTION
Fix Github action pipeline when uploading artifacts to Github release.