### PR TITLE
OPCT-257: CI/set prerelease flag when pipeline creates release

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -64,10 +64,11 @@ jobs:
 
       # https://github.com/softprops/action-gh-release
       - name: Create Release
-        uses: softprops/action-gh-release@v0.1.15
+        uses: softprops/action-gh-release@v2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
+          prerelease: true
           files: |
             build/opct-*
           body: |


### PR DESCRIPTION
Mark as pre-releases the releases created by CI pipeline, instead of `Latestt`. Letting latest marked manually allowing creating many pre-releases without manual intervention