### PR TITLE
OPCT-257: CI - add service account to publish to new Quay Org

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -6,7 +6,7 @@ on:
       - '*'
 
 env:
-  CONTAINER_REPO: quay.io/ocp-cert/opct
+  CONTAINER_REPO: quay.io/opct/opct
   RELEASE_TAG: ${{ github.ref_name }}
 
 jobs:
@@ -41,8 +41,8 @@ jobs:
 
       - name: Build Container and Release to Quay
         env:
-          QUAY_USER: ${{ secrets.QUAY_USER }}
-          QUAY_PASS: ${{ secrets.QUAY_PASS }}
+          QUAY_USER: ${{ secrets.QUAY_OPCT_USER }}
+          QUAY_PASS: ${{ secrets.QUAY_OPCT_PASS }}
         run: |
           echo "> Logging to Quay.io:"
           podman login -u="${QUAY_USER}" -p="${QUAY_PASS}" quay.io


### PR DESCRIPTION
Update to the official Quay Org which other images is already published: @opct

Changes in this repo updates the CI pipeline to publish to new Org/repo when a release is created.

Prerequisites is complete:
 - repo `opct/opct` created
 - robot account for this project created adding grants to that repo
 - github secrets updated with new service account3

Migrating from: https://quay.io/repository/ocp-cert/opct?tab=tags
To repo: https://quay.io/repository/opct/opct


