### PR TITLE
OPCT-257: bump plugins to v0.5.0

### DIFF
--- a/pkg/types.go
+++ b/pkg/types.go
@@ -19,9 +19,9 @@ const (
 	SonobuoyLabelComponentName     = "component"
 	SonobuoyLabelComponentValue    = "sonobuoy"
 	DefaultToolsRepository         = "quay.io/opct"
-	PluginsImage                   = "plugin-openshift-tests:v0.5.0-alpha.5"
-	CollectorImage                 = "plugin-artifacts-collector:v0.5.0-alpha.5"
-	MustGatherMonitoringImage      = "must-gather-monitoring:v0.5.0-alpha.5"
+	PluginsImage                   = "plugin-openshift-tests:v0.5.0"
+	CollectorImage                 = "plugin-artifacts-collector:v0.5.0"
+	MustGatherMonitoringImage      = "must-gather-monitoring:v0.5.0"
 	OpenShiftTestsImage            = "image-registry.openshift-image-registry.svc:5000/openshift/tests"
 )
 


### PR DESCRIPTION
Bump plugins version to v0.5.0 GA

https://github.com/redhat-openshift-ecosystem/provider-certification-plugins/actions/runs/10308276521

https://issues.redhat.com/browse/OPCT-257