### PR TITLE
OPCT-300: fix kubernetes service URL

### DIFF
--- a/data/templates/plugins/openshift-cluster-upgrade.yaml
+++ b/data/templates/plugins/openshift-cluster-upgrade.yaml
@@ -31,7 +31,7 @@ podSpec:
         - name: KUBECONFIG
           value: "/tmp/shared/kubeconfig"
         - name: KUBE_API_URL
-          value: "https://172.30.0.1:443"
+          value: "https://kubernetes.default.svc:443"
         - name: SA_TOKEN_PATH
           value: "/var/run/secrets/kubernetes.io/serviceaccount/token"
         - name: SA_CA_PATH

--- a/data/templates/plugins/openshift-conformance-replay.yaml
+++ b/data/templates/plugins/openshift-conformance-replay.yaml
@@ -31,7 +31,7 @@ podSpec:
         - name: KUBECONFIG
           value: /tmp/shared/kubeconfig
         - name: KUBE_API_URL
-          value: "https://172.30.0.1:443"
+          value: "https://kubernetes.default.svc:443"
         - name: SA_TOKEN_PATH
           value: /var/run/secrets/kubernetes.io/serviceaccount/token
         - name: SA_CA_PATH

--- a/data/templates/plugins/openshift-conformance-validated.yaml
+++ b/data/templates/plugins/openshift-conformance-validated.yaml
@@ -31,7 +31,7 @@ podSpec:
         - name: KUBECONFIG
           value: "/tmp/shared/kubeconfig"
         - name: KUBE_API_URL
-          value: "https://172.30.0.1:443"
+          value: "https://kubernetes.default.svc:443"
         - name: SA_TOKEN_PATH
           value: "/var/run/secrets/kubernetes.io/serviceaccount/token"
         - name: SA_CA_PATH

--- a/data/templates/plugins/openshift-kube-conformance.yaml
+++ b/data/templates/plugins/openshift-kube-conformance.yaml
@@ -31,7 +31,7 @@ podSpec:
         - name: KUBECONFIG
           value: "/tmp/shared/kubeconfig"
         - name: KUBE_API_URL
-          value: "https://172.30.0.1:443"
+          value: "https://kubernetes.default.svc:443"
         - name: SA_TOKEN_PATH
           value: "/var/run/secrets/kubernetes.io/serviceaccount/token"
         - name: SA_CA_PATH


### PR DESCRIPTION
This PR fixes the wrong kubernetes login URL by preventing silent failures when the service network is different than default `172.30.0.0/1` and kubernetes services will not be the URL `https://172.30.0.1:443`

Example of Prow job failing: https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/openshift_release/54722/rehearse-54722-periodic-ci-openshift-assisted-test-infra-master-opct-oci-assisted-periodic/1823146446296190976

```sh
$ oc get pods -n opct
NAME                                                               READY   STATUS       RESTARTS   AGE
sonobuoy                                                           1/1     Running      0          111m
sonobuoy-05-openshift-cluster-upgrade-job-15de00c8fa24452e         0/3     Init:Error   0          111m
sonobuoy-10-openshift-kube-conformance-job-b28f3100081d4e08        0/3     Init:Error   0          111m
sonobuoy-20-openshift-conformance-validated-job-7077ce6ca9124854   0/3     Init:Error   0          111m
sonobuoy-80-openshift-tests-replay-job-3c99fbc95e6e4f65            0/3     Init:Error   0          111m
sonobuoy-99-openshift-artifacts-collector-job-22d98d91c14a44f0     0/2     Completed    0          111m

$ oc describe pod sonobuoy-05-openshift-cluster-upgrade-job-15de00c8fa24452e -n opct
Name:                 sonobuoy-05-openshift-cluster-upgrade-job-15de00c8fa24452e
Namespace:            opct
...
Init Containers:
...
  login:
    Container ID:  cri-o://ad12137cfb4d21d0404592ae0964c4ca4cfd12a96f47cd1737ebcd385f58be2f
    Image:         image-registry.openshift-image-registry.svc:5000/openshift/tests
    Image ID:      image-registry.openshift-image-registry.svc:5000/openshift/tests@sha256:938a26fe08ceb2927eef9b5a468ecb1fd59530d430e2c1e07abdeeca6e3e0866
    Port:          <none>
    Host Port:     <none>
    Command:
      /bin/bash
      -c
      /usr/bin/oc login "${KUBE_API_URL}" \
        --token="$(cat "${SA_TOKEN_PATH}")" \
        --certificate-authority="${SA_CA_PATH}";
      
    State:          Terminated
      Reason:       Error
      Exit Code:    1
      Started:      Tue, 13 Aug 2024 01:42:14 +0000
      Finished:     Tue, 13 Aug 2024 01:42:44 +0000
    Ready:          False
    Restart Count:  0
    Environment:
      KUBECONFIG:     /tmp/shared/kubeconfig
      KUBE_API_URL:   https://172.30.0.1:443
      SA_TOKEN_PATH:  /var/run/secrets/kubernetes.io/serviceaccount/token
      SA_CA_PATH:     /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
...

$ oc logs -c login sonobuoy-05-openshift-cluster-upgrade-job-15de00c8fa24452e -n opct
error: dial tcp 172.30.0.1:443: i/o timeout - verify you have provided the correct host and port and that the server is currently running.

$ oc get svc/kubernetes -n default
NAME         TYPE        CLUSTER-IP   EXTERNAL-IP   PORT(S)   AGE
kubernetes   ClusterIP   10.128.0.1   <none>        443/TCP   160m
```