### PR TITLE
OPCT-257: Increase verbosity on status loop to detect failures

### DIFF
--- a/pkg/retrieve/retrieve.go
+++ b/pkg/retrieve/retrieve.go
@@ -4,9 +4,9 @@ import (
 	"fmt"
 	"io"
 	"os"
-	"time"
-	"strings"
 	"path/filepath"
+	"strings"
+	"time"
 
 	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
@@ -16,7 +16,6 @@ import (
 	"golang.org/x/sync/errgroup"
 
 	"github.com/redhat-openshift-ecosystem/provider-certification-tool/pkg"
-	"github.com/redhat-openshift-ecosystem/provider-certification-tool/pkg/client"
 	"github.com/redhat-openshift-ecosystem/provider-certification-tool/pkg/status"
 )
 
@@ -42,20 +41,13 @@ func NewCmdRetrieve() *cobra.Command {
 				}
 			}
 
-			kclient, sclient, err := client.CreateClients()
-			if err != nil {
-				return fmt.Errorf("retrieve finished with errors: %v", err)
-			}
-
 			s := status.NewStatusOptions(&status.StatusInput{Watch: false})
-			err = s.PreRunCheck(kclient)
-			if err != nil {
+			if err := s.PreRunCheck(); err != nil {
 				return fmt.Errorf("retrieve finished with errors: %v", err)
 			}
 
 			log.Info("Collecting results...")
-
-			if err := retrieveResultsRetry(sclient, destinationDirectory); err != nil {
+			if err := retrieveResultsRetry(s.GetSonobuoyClient(), destinationDirectory); err != nil {
 				return fmt.Errorf("retrieve finished with errors: %v", err)
 			}
 

--- a/pkg/status/printer.go
+++ b/pkg/status/printer.go
@@ -1,13 +1,21 @@
 package status
 
 import (
+	"context"
 	"fmt"
 	"html/template"
 	"os"
 	"sort"
 	"time"
 
+	"github.com/redhat-openshift-ecosystem/provider-certification-tool/pkg"
+	log "github.com/sirupsen/logrus"
 	"github.com/vmware-tanzu/sonobuoy/pkg/plugin/aggregation"
+
+	kcorev1 "k8s.io/api/core/v1"
+	kmmetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	klabels "k8s.io/apimachinery/pkg/labels"
+	"k8s.io/client-go/kubernetes"
 )
 
 type PrintableStatus struct {
@@ -30,31 +38,40 @@ var runningStatusTemplate = `{{.CurrentTime}}|{{.ElapsedTime}}> Global Status: {
 {{printf "%-34s | %-10s | %-10s | %-25s | %-50s" $pl.Name $pl.Status $pl.Result $pl.Progress $pl.Message}}{{end}}
 `
 
-func PrintRunningStatus(s *aggregation.Status, start time.Time) error {
-	ps := getPrintableRunningStatus(s, start)
+func (s *StatusOptions) printRunningStatus() error {
 	statusTemplate, err := template.New("statusTemplate").Parse(runningStatusTemplate)
 	if err != nil {
 		return err
 	}
-
-	err = statusTemplate.Execute(os.Stdout, ps)
-	return err
+	return statusTemplate.Execute(os.Stdout, s.getPrintableRunningStatus())
 }
 
-func getPrintableRunningStatus(s *aggregation.Status, start time.Time) PrintableStatus {
+func (s *StatusOptions) getPrintableRunningStatus() PrintableStatus {
 	now := time.Now()
 	ps := PrintableStatus{
-		GlobalStatus: s.Status,
+		GlobalStatus: s.Latest.Status,
 		CurrentTime:  now.Format(time.RFC1123),
-		ElapsedTime:  now.Sub(start).String(),
+		ElapsedTime:  now.Sub(s.StartTime).String(),
 	}
 
-	for _, pl := range s.Plugins {
+	for _, pl := range s.Latest.Plugins {
 		var progress string
 		var message string
 
 		if pl.Progress != nil {
 			progress = fmt.Sprintf("%d/%d (%d failures)", pl.Progress.Completed, pl.Progress.Total, len(pl.Progress.Failures))
+		}
+		// Get PodStatus from the plugin when progress API is not available, allowing a
+		// better visibility when issues to schedule jobs.
+		if len(progress) == 0 {
+			pod, err := getPluginPod(s.kclient, pkg.CertificationNamespace, pl.Plugin)
+			var podStatus string
+			if err != nil {
+				podStatus = err.Error()
+			} else {
+				podStatus = getPodStatusString(pod)
+			}
+			message = fmt.Sprintf("waiting for jobs initialization=PodStatus(%s)", podStatus)
 		}
 
 		if pl.Status == aggregation.RunningStatus {
@@ -67,9 +84,13 @@ func getPrintableRunningStatus(s *aggregation.Status, start time.Time) Printable
 				message = pl.Status
 			}
 		} else {
+			// If we have results, print a summary of the results, otherwise just print the waiting message.
 			passCount := pl.ResultStatusCounts["passed"]
 			failedCount := pl.ResultStatusCounts["failed"]
-			message = fmt.Sprintf("Total tests processed: %d (%d pass / %d failed)", passCount+failedCount, passCount, failedCount)
+			if passCount+failedCount != 0 {
+				message = fmt.Sprintf("Total tests processed: %d (%d pass / %d failed)", passCount+failedCount, passCount, failedCount)
+			}
+
 		}
 
 		pls := PrintablePluginStatus{
@@ -87,4 +108,59 @@ func getPrintableRunningStatus(s *aggregation.Status, start time.Time) Printable
 	})
 
 	return ps
+}
+
+// GetPluginPod get the plugin pod spec.
+func getPluginPod(kclient kubernetes.Interface, namespace string, pluginPodName string) (*kcorev1.Pod, error) {
+	labelSelector := kmmetav1.LabelSelector{MatchLabels: map[string]string{"component": "sonobuoy", "sonobuoy-plugin": pluginPodName}}
+	log.Debugf("Getting pod with labels: %v\n", labelSelector)
+	listOptions := kmmetav1.ListOptions{
+		LabelSelector: klabels.Set(labelSelector.MatchLabels).String(),
+	}
+
+	podList, err := kclient.CoreV1().Pods(namespace).List(context.TODO(), listOptions)
+	if err != nil {
+		return nil, fmt.Errorf("unable to list pods with label %q", labelSelector)
+	}
+
+	switch {
+	case len(podList.Items) == 0:
+		log.Warnf("no pods found with label %q in namespace %s", labelSelector, namespace)
+		return nil, fmt.Errorf(fmt.Sprintf("no pods found with label %q in namespace %s", labelSelector, namespace))
+
+	case len(podList.Items) > 1:
+		log.Warnf("Found more than one pod with label %q. Using pod with name %q", labelSelector, podList.Items[0].GetName())
+		return &podList.Items[0], nil
+	default:
+		return &podList.Items[0], nil
+	}
+}
+
+// getPodStatusString get the pod status string.
+func getPodStatusString(pod *kcorev1.Pod) string {
+	if pod == nil {
+		return "TBD(pod)"
+	}
+
+	for _, cond := range pod.Status.Conditions {
+		// Pod Running
+		if cond.Type == kcorev1.PodReady &&
+			cond.Status == kcorev1.ConditionTrue &&
+			pod.Status.Phase == kcorev1.PodRunning {
+			return "Running"
+		}
+		// Pod Completed
+		if cond.Type == kcorev1.PodReady &&
+			cond.Status == "False" &&
+			cond.Reason == "PodCompleted" {
+			return "Completed"
+		}
+		// Pod NotReady (Container)
+		if cond.Type == kcorev1.PodReady &&
+			cond.Status == "False" &&
+			cond.Reason == "ContainersNotReady" {
+			return "NotReady"
+		}
+	}
+	return string(pod.Status.Phase)
 }

--- a/pkg/status/printer_test.go
+++ b/pkg/status/printer_test.go
@@ -12,26 +12,28 @@ import (
 )
 
 func Test_PrintStatus(t *testing.T) {
-	a := &aggregation.Status{
-		Plugins: []aggregation.PluginStatus{
-			{
-				Plugin:             "test",
-				Status:             "running",
-				ResultStatus:       "failed",
-				ResultStatusCounts: map[string]int{"passed": 10, "failed": 5},
-				Progress: &plugin.ProgressUpdate{
-					Total:     30,
-					Completed: 10,
-					Errors:    nil,
-					Failures:  []string{"a", "b", "c"},
-					Message:   "waiting post-processor...",
+	status := &StatusOptions{
+		StartTime: time.Now(),
+		Latest: &aggregation.Status{
+			Plugins: []aggregation.PluginStatus{
+				{
+					Plugin:             "test",
+					Status:             "running",
+					ResultStatus:       "failed",
+					ResultStatusCounts: map[string]int{"passed": 10, "failed": 5},
+					Progress: &plugin.ProgressUpdate{
+						Total:     30,
+						Completed: 10,
+						Errors:    nil,
+						Failures:  []string{"a", "b", "c"},
+						Message:   "waiting post-processor...",
+					},
 				},
 			},
+			Status: "running",
 		},
-		Status: "running",
 	}
-	now := time.Now()
-	ps := getPrintableRunningStatus(a, now)
+	ps := status.getPrintableRunningStatus()
 
 	tmpl, err := template.New("test").Parse(runningStatusTemplate)
 	if err != nil {


### PR DESCRIPTION
The changes in the status summary loop, increases the verbosity by collecting the pod status when there is no information from aggregator. It can help to quickly detect failures in the environment.

Example of "silent failure" happening in a [CI job][1]:

~~~
Tue, 13 Aug 2024 03:43:52 UTC|2h2m50.961758625s> Global Status: running
JOB_NAME | STATUS | RESULTS | PROGRESS | MESSAGE
05-openshift-cluster-upgrade | running | | | waiting for jobs initialization=PodStatus(Failed)
10-openshift-kube-conformance | running | | | waiting for jobs initialization=PodStatus(Failed)
20-openshift-conformance-validated | running | | | waiting for jobs initialization=PodStatus(Failed)
80-openshift-tests-replay | running | | | waiting for jobs initialization=PodStatus(Failed)
99-openshift-artifacts-collector | complete | | 0/0 (0 failures) | complete
~~~

[1]: https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/openshift_release/54722/rehearse-54722-periodic-ci-openshift-assisted-test-infra-master-opct-oci-assisted-periodic/1823146446296190976

The follow up card https://issues.redhat.com/browse/OPCT-301 has been created to investigate a solution to a context timeout to prevent running forever.