### PR TITLE
OPCT-257:  fix status cmd must not required clients to init command

### DIFF
--- a/pkg/retrieve/retrieve.go
+++ b/pkg/retrieve/retrieve.go
@@ -41,7 +41,7 @@ func NewCmdRetrieve() *cobra.Command {
 				}
 			}
 
-			s := status.NewStatusOptions(&status.StatusInput{Watch: false})
+			s := status.NewStatus(&status.StatusInput{Watch: false})
 			if err := s.PreRunCheck(); err != nil {
 				return fmt.Errorf("retrieve finished with errors: %v", err)
 			}

--- a/pkg/run/run.go
+++ b/pkg/run/run.go
@@ -124,11 +124,8 @@ func NewCmdRun() *cobra.Command {
 				return err
 			}
 
-			// Sleep to give status time to appear
-			// time.Sleep(status.StatusInterval)
-
 			// Retrieve the first status and print it, finishing when --watch is not set.
-			s := status.NewStatusOptions(&status.StatusInput{
+			s := status.NewStatus(&status.StatusInput{
 				Watch:   o.watch,
 				KClient: kclient,
 				SClient: sclient,

--- a/pkg/status/cmd.go
+++ b/pkg/status/cmd.go
@@ -1,0 +1,61 @@
+package status
+
+import (
+	"github.com/redhat-openshift-ecosystem/provider-certification-tool/pkg/wait"
+	log "github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+)
+
+// cmdStatusArgs is the struct to store the input arguments for the status command.
+type cmdInputStatus struct {
+	Watch           bool
+	IntervalSeconds int
+}
+
+var cmdArgsStatus cmdInputStatus
+var cmdStatus = &cobra.Command{
+	Use:     "status",
+	Example: "opct status --watch",
+	Short:   "Show the current status of the validation tool",
+	Long:    ``,
+	RunE:    cmdStatusRun,
+}
+
+func init() {
+	cmdStatus.PersistentFlags().BoolVarP(&cmdArgsStatus.Watch, "watch", "w", false, "Keep watch status after running")
+	cmdStatus.Flags().IntVarP(&cmdArgsStatus.IntervalSeconds, "watch-interval", "", DefaultStatusIntervalSeconds, "Interval to watch the status and print in the stdout")
+}
+
+func NewCmdStatus() *cobra.Command {
+	return cmdStatus
+}
+
+func cmdStatusRun(cmd *cobra.Command, args []string) error {
+	o := NewStatus(&StatusInput{
+		Watch:           cmdArgsStatus.Watch,
+		IntervalSeconds: cmdArgsStatus.IntervalSeconds,
+	})
+	// Pre-checks and setup
+	if err := o.PreRunCheck(); err != nil {
+		log.WithError(err).Error("error running pre-checks")
+		return err
+	}
+
+	// Wait for Sonobuoy to create
+	if err := wait.WaitForRequiredResources(o.kclient); err != nil {
+		log.WithError(err).Error("error waiting for sonobuoy pods to become ready")
+		return err
+	}
+
+	// Wait for Sononbuoy to start reporting status
+	if err := o.WaitForStatusReport(cmd.Context()); err != nil {
+		log.WithError(err).Error("error retrieving current aggregator status")
+		return err
+	}
+
+	if err := o.Print(cmd); err != nil {
+		log.WithError(err).Error("error printing status")
+		return err
+	}
+	return nil
+}

--- a/pkg/status/printer_test.go
+++ b/pkg/status/printer_test.go
@@ -11,8 +11,8 @@ import (
 	"github.com/vmware-tanzu/sonobuoy/pkg/plugin/aggregation"
 )
 
-func Test_PrintStatus(t *testing.T) {
-	status := &StatusOptions{
+func Test_printStatus(t *testing.T) {
+	status := &Status{
 		StartTime: time.Now(),
 		Latest: &aggregation.Status{
 			Plugins: []aggregation.PluginStatus{

--- a/pkg/status/utils.go
+++ b/pkg/status/utils.go
@@ -1,0 +1,67 @@
+package status
+
+import (
+	"context"
+	"fmt"
+
+	log "github.com/sirupsen/logrus"
+	kcorev1 "k8s.io/api/core/v1"
+	kmmetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	klabels "k8s.io/apimachinery/pkg/labels"
+	"k8s.io/client-go/kubernetes"
+)
+
+// GetPluginPod get the plugin pod spec.
+func getPluginPod(kclient kubernetes.Interface, namespace string, pluginPodName string) (*kcorev1.Pod, error) {
+	labelSelector := kmmetav1.LabelSelector{MatchLabels: map[string]string{"component": "sonobuoy", "sonobuoy-plugin": pluginPodName}}
+	log.Debugf("Getting pod with labels: %v\n", labelSelector)
+	listOptions := kmmetav1.ListOptions{
+		LabelSelector: klabels.Set(labelSelector.MatchLabels).String(),
+	}
+
+	podList, err := kclient.CoreV1().Pods(namespace).List(context.TODO(), listOptions)
+	if err != nil {
+		return nil, fmt.Errorf("unable to list pods with label %q", labelSelector)
+	}
+
+	switch {
+	case len(podList.Items) == 0:
+		log.Warnf("no pods found with label %q in namespace %s", labelSelector, namespace)
+		return nil, fmt.Errorf(fmt.Sprintf("no pods found with label %q in namespace %s", labelSelector, namespace))
+
+	case len(podList.Items) > 1:
+		log.Warnf("Found more than one pod with label %q. Using pod with name %q", labelSelector, podList.Items[0].GetName())
+		return &podList.Items[0], nil
+	default:
+		return &podList.Items[0], nil
+	}
+}
+
+// getPodStatusString get the pod status string.
+func getPodStatusString(pod *kcorev1.Pod) string {
+	if pod == nil {
+		return "TBD(pod)"
+	}
+
+	for _, cond := range pod.Status.Conditions {
+		// Pod Running
+		if cond.Type == kcorev1.PodReady &&
+			cond.Status == kcorev1.ConditionTrue &&
+			pod.Status.Phase == kcorev1.PodRunning {
+			return "Running"
+		}
+		// Pod Completed
+		if cond.Type == kcorev1.PodReady &&
+			cond.Status == "False" &&
+			cond.Reason == "PodCompleted" {
+			return "Completed"
+		}
+		// Pod NotReady (Container)
+		if cond.Type == kcorev1.PodReady &&
+			cond.Status == "False" &&
+			cond.Reason == "ContainersNotReady" {
+			return "NotReady"
+		}
+	}
+	return string(pod.Status.Phase)
+}

--- a/pkg/status/utils_test.go
+++ b/pkg/status/utils_test.go
@@ -1,0 +1,54 @@
+package status
+
+import (
+	"testing"
+
+	kcorev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+func TestGetPluginPod(t *testing.T) {
+	kclient := fake.NewSimpleClientset(&kcorev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-pod",
+			Namespace: "test-namespace",
+			Labels: map[string]string{
+				"component":       "sonobuoy",
+				"sonobuoy-plugin": "test-plugin",
+			},
+		},
+	})
+
+	namespace := "test-namespace"
+	pluginPodName := "test-plugin"
+
+	pod, err := getPluginPod(kclient, namespace, pluginPodName)
+	if err != nil {
+		t.Errorf("getPluginPod() returned an error: %v", err)
+	}
+
+	expectedPodName := "test-pod"
+	if pod.Name != expectedPodName {
+		t.Errorf("getPluginPod() returned the wrong pod. Expected: %s, Got: %s", expectedPodName, pod.Name)
+	}
+}
+func TestGetPodStatusString(t *testing.T) {
+	pod := &kcorev1.Pod{
+		Status: kcorev1.PodStatus{
+			Phase: kcorev1.PodRunning,
+			Conditions: []kcorev1.PodCondition{
+				{
+					Type:   kcorev1.PodReady,
+					Status: kcorev1.ConditionTrue,
+				},
+			},
+		},
+	}
+
+	expectedStatus := "Running"
+	status := getPodStatusString(pod)
+	if status != expectedStatus {
+		t.Errorf("getPodStatusString() returned the wrong status. Expected: %s, Got: %s", expectedStatus, status)
+	}
+}

--- a/pkg/types.go
+++ b/pkg/types.go
@@ -19,9 +19,9 @@ const (
 	SonobuoyLabelComponentName     = "component"
 	SonobuoyLabelComponentValue    = "sonobuoy"
 	DefaultToolsRepository         = "quay.io/opct"
-	PluginsImage                   = "plugin-openshift-tests:v0.0.0-devel-3885cb6"
-	CollectorImage                 = "plugin-artifacts-collector:v0.0.0-devel-3885cb6"
-	MustGatherMonitoringImage      = "must-gather-monitoring:v0.0.0-devel-3885cb6"
+	PluginsImage                   = "plugin-openshift-tests:v0.5.0"
+	CollectorImage                 = "plugin-artifacts-collector:v0.5.0"
+	MustGatherMonitoringImage      = "must-gather-monitoring:v0.5.0"
 	OpenShiftTestsImage            = "image-registry.openshift-image-registry.svc:5000/openshift/tests"
 )
 

--- a/pkg/types.go
+++ b/pkg/types.go
@@ -19,9 +19,9 @@ const (
 	SonobuoyLabelComponentName     = "component"
 	SonobuoyLabelComponentValue    = "sonobuoy"
 	DefaultToolsRepository         = "quay.io/opct"
-	PluginsImage                   = "plugin-openshift-tests:v0.5.0"
-	CollectorImage                 = "plugin-artifacts-collector:v0.5.0"
-	MustGatherMonitoringImage      = "must-gather-monitoring:v0.5.0"
+	PluginsImage                   = "plugin-openshift-tests:v0.0.0-devel-3885cb6"
+	CollectorImage                 = "plugin-artifacts-collector:v0.0.0-devel-3885cb6"
+	MustGatherMonitoringImage      = "must-gather-monitoring:v0.0.0-devel-3885cb6"
 	OpenShiftTestsImage            = "image-registry.openshift-image-registry.svc:5000/openshift/tests"
 )
 


### PR DESCRIPTION
The command initialization must have minimal to no external dependencies to create the command.

Currently OPCT commands have been with some dependencies to initialize the `Run` command, which isn't the best practice.

The #118 introduced a new external dependency requiring a live cluster when the cobra is creating and initializing the command (without triggering it), which isn't expected nor desired, as OPCT tool provides many capabilities to operate without access to O/K API, such as `report` command which is affected raising an error after #118:

~~~
$ opct-devel report --save-to res opct_202408131745_9dd0adf1-df49-44fd-ae32-9c2ace0946c9.tar.gz --log-level=debug
ERRO[0000] error creating clients: error creating sonobuoy rest helper: could not get api group resources: Get "https://api.opct-base-05.devcluster.openshift.com:6443/api?timeout=32s": dial tcp: lookup api.opct-base-05.devcluster.openshift.com on 192.168.15.1:53: no such host  error="error creating sonobuoy rest helper: could not get api group resources: Get \"https://api.opct-base-05.devcluster.openshift.com:6443/api?timeout=32s\": dial tcp: lookup api.opct-base-05.devcluster.openshift.com on 192.168.15.1:53: no such host"

~~~

The changes here creates declares the cmd Status as a var, declaring the `Run` as an external function.