### PR TITLE
NO-JIRA: enhance version command with cluster version

### DIFF
--- a/pkg/version/cluster.go
+++ b/pkg/version/cluster.go
@@ -1,0 +1,72 @@
+package version
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+
+	"github.com/redhat-openshift-ecosystem/opct/pkg/client"
+	"github.com/spf13/viper"
+	"k8s.io/client-go/kubernetes"
+
+	coclient "github.com/openshift/client-go/config/clientset/versioned"
+	log "github.com/sirupsen/logrus"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+type ClusterVersion struct {
+	OpenShift  string `json:"openshift"`
+	Kubernetes string `json:"kubernetes"`
+}
+
+func GetClusterVersion() (*ClusterVersion, error) {
+	fmt.Printf("Cluster version:")
+	if !viper.IsSet("kubeconfig") {
+		fmt.Printf(" unknown (KUBECONFIG is not set)\n")
+		return nil, errors.New("KUBECONFIG is not set")
+	}
+
+	var cli *client.Client
+	var err error
+	cli, err = client.NewClient()
+	if err != nil {
+		log.WithError(err).Error("pre-run failed when creating clients")
+		os.Exit(1)
+	}
+	oc, err := coclient.NewForConfig(cli.RestConfig)
+	if err != nil {
+		log.WithError(err).Error("pre-run failed when creating clients")
+		os.Exit(1)
+	}
+
+	// Get OpenShift version
+	cv, err := oc.ConfigV1().ClusterVersions().Get(context.TODO(), "version", metav1.GetOptions{})
+	if err != nil {
+		log.Warnf("Failed to get cluster version, defaulting to kubernetes/conformance suite with openshift-tests: %v", err)
+		os.Exit(1)
+	}
+
+	versionString := " unknown (unable to get cluster version)"
+	version := cv.Status.Desired.Version
+	if version != "" {
+		versionString = version
+	}
+
+	// Retrieve kubernetes version
+	kubeClient, err := kubernetes.NewForConfig(cli.RestConfig)
+	if err != nil {
+		log.WithError(err).Error("pre-run failed when creating clients")
+		os.Exit(1)
+	}
+	kubeVersion, err := kubeClient.Discovery().ServerVersion()
+	if err != nil {
+		log.WithError(err).Error("pre-run failed when creating clients")
+		os.Exit(1)
+	}
+
+	return &ClusterVersion{
+		OpenShift:  versionString,
+		Kubernetes: kubeVersion.String(),
+	}, nil
+}

--- a/pkg/version/cluster_test.go
+++ b/pkg/version/cluster_test.go
@@ -1,0 +1,163 @@
+package version
+
+import (
+	"bytes"
+	"io"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/spf13/viper"
+)
+
+func TestClusterVersion_Fields(t *testing.T) {
+	// Test ClusterVersion struct field assignment
+	cv := ClusterVersion{
+		OpenShift:  "4.15.0",
+		Kubernetes: "v1.28.0",
+	}
+
+	if cv.OpenShift != "4.15.0" {
+		t.Errorf("ClusterVersion.OpenShift = %q, want %q", cv.OpenShift, "4.15.0")
+	}
+
+	if cv.Kubernetes != "v1.28.0" {
+		t.Errorf("ClusterVersion.Kubernetes = %q, want %q", cv.Kubernetes, "v1.28.0")
+	}
+}
+
+func TestGetClusterVersion_NoKubeconfig(t *testing.T) {
+	// Save original viper state
+	originalKubeconfig := viper.Get("kubeconfig")
+	defer func() {
+		if originalKubeconfig != nil {
+			viper.Set("kubeconfig", originalKubeconfig)
+		} else {
+			// Reset viper to clean state
+			viper.Reset()
+		}
+	}()
+
+	// Ensure kubeconfig is not set
+	viper.Reset()
+
+	// Capture stdout
+	oldStdout := os.Stdout
+	r, w, _ := os.Pipe()
+	os.Stdout = w
+
+	result, err := GetClusterVersion()
+
+	// Restore stdout
+	if closeErr := w.Close(); closeErr != nil {
+		t.Fatalf("Failed to close pipe writer: %v", closeErr)
+	}
+	os.Stdout = oldStdout
+
+	// Read captured output
+	var buf bytes.Buffer
+	if _, copyErr := io.Copy(&buf, r); copyErr != nil {
+		t.Fatalf("Failed to copy pipe output: %v", copyErr)
+	}
+	output := buf.String()
+
+	// Verify error is returned
+	if err == nil {
+		t.Error("GetClusterVersion() expected error when KUBECONFIG is not set, got nil")
+	}
+
+	expectedError := "KUBECONFIG is not set"
+	if err.Error() != expectedError {
+		t.Errorf("GetClusterVersion() error = %q, want %q", err.Error(), expectedError)
+	}
+
+	// Verify result is nil
+	if result != nil {
+		t.Errorf("GetClusterVersion() result = %v, want nil", result)
+	}
+
+	// Verify output contains expected message
+	expectedOutputs := []string{
+		"Cluster version:",
+		"unknown (KUBECONFIG is not set)",
+	}
+
+	for _, expected := range expectedOutputs {
+		if !strings.Contains(output, expected) {
+			t.Errorf("GetClusterVersion() output missing %q\nGot: %s", expected, output)
+		}
+	}
+}
+
+func TestGetClusterVersion_WithKubeconfigSet(t *testing.T) {
+	// This test verifies behavior when KUBECONFIG is set but connection fails
+	// Note: Full integration testing would require mocking the Kubernetes client,
+	// which is not straightforward with the current implementation due to:
+	// 1. Direct os.Exit() calls that terminate the test process
+	// 2. Tight coupling with client creation
+	// 3. No dependency injection for client interfaces
+	//
+	// For comprehensive testing, the GetClusterVersion function would need refactoring to:
+	// - Accept client interfaces as dependencies
+	// - Return errors instead of calling os.Exit()
+	// - Separate output formatting from business logic
+
+	t.Skip("Skipping integration test - requires refactoring to support dependency injection")
+
+	// Future improvement: Refactor GetClusterVersion to accept interfaces:
+	// func GetClusterVersion(configClient ConfigClientInterface, kubeClient KubeClientInterface) (*ClusterVersion, error)
+}
+
+func TestClusterVersion_ZeroValue(t *testing.T) {
+	// Test zero value initialization
+	var cv ClusterVersion
+
+	if cv.OpenShift != "" {
+		t.Errorf("Zero value ClusterVersion.OpenShift = %q, want empty string", cv.OpenShift)
+	}
+
+	if cv.Kubernetes != "" {
+		t.Errorf("Zero value ClusterVersion.Kubernetes = %q, want empty string", cv.Kubernetes)
+	}
+}
+
+func TestClusterVersion_Equality(t *testing.T) {
+	cv1 := ClusterVersion{
+		OpenShift:  "4.15.0",
+		Kubernetes: "v1.28.0",
+	}
+
+	cv2 := ClusterVersion{
+		OpenShift:  "4.15.0",
+		Kubernetes: "v1.28.0",
+	}
+
+	cv3 := ClusterVersion{
+		OpenShift:  "4.16.0",
+		Kubernetes: "v1.29.0",
+	}
+
+	// Test equality
+	if cv1 != cv2 {
+		t.Errorf("Expected cv1 == cv2, but they are not equal")
+	}
+
+	// Test inequality
+	if cv1 == cv3 {
+		t.Errorf("Expected cv1 != cv3, but they are equal")
+	}
+}
+
+// Note: Additional test coverage would require refactoring GetClusterVersion to:
+// 1. Remove direct os.Exit() calls - return errors instead
+// 2. Accept client interfaces as parameters (dependency injection)
+// 3. Separate output formatting (fmt.Printf) from business logic
+//
+// Example refactored signature:
+//   func GetClusterVersion(ctx context.Context, client ClientInterface) (*ClusterVersion, error)
+//
+// This would enable:
+// - Mocking client responses
+// - Testing error paths without process termination
+// - Testing business logic independently of I/O
+// - Improved testability and maintainability

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -4,8 +4,10 @@ package version
 
 import (
 	"fmt"
+	"os"
 
 	"github.com/redhat-openshift-ecosystem/opct/pkg"
+	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"github.com/vmware-tanzu/sonobuoy/pkg/buildinfo"
 )
@@ -29,21 +31,40 @@ type VersionContext struct {
 }
 
 func (vc *VersionContext) String() string {
-	return fmt.Sprintf("OPCT CLI: %s+%s", vc.Version, vc.Commit)
+	if vc.Version == "0.0.0" {
+		return fmt.Sprintf("OPCT CLI: %s+%s", vc.Version, vc.Commit)
+	}
+	return fmt.Sprintf("OPCT CLI: %s", vc.Version)
 }
 
-func (vc *VersionContext) StringPlugins() string {
-	return fmt.Sprintf("OPCT Plugins: %s", pkg.PluginsImage)
+func (vc *VersionContext) stringPluginsImage() {
+	fmt.Printf("Images versions:")
+	fmt.Printf("\n %s (library %s)", pkg.SonobuoyImage, buildinfo.Version)
+	fmt.Printf("\n %s", pkg.PluginsImage)
+	fmt.Printf("\n %s", pkg.CollectorImage)
+	fmt.Printf("\n %s", pkg.MustGatherMonitoringImage)
+	fmt.Println("")
 }
 
 func NewCmdVersion() *cobra.Command {
 	return &cobra.Command{
 		Use:   "version",
-		Short: "Print provider validation tool version",
+		Short: "Print opct CLI version",
 		Run: func(cmd *cobra.Command, args []string) {
 			fmt.Println(Version.String())
-			fmt.Println(Version.StringPlugins())
-			fmt.Printf("Sonobuoy: %s\n", buildinfo.Version)
+			Version.stringPluginsImage()
+			// get cluster version if KUBECONFIG is set
+			clusterVersion, err := GetClusterVersion()
+			if err != nil {
+				if err.Error() == "KUBECONFIG is not set" {
+					os.Exit(0)
+				}
+				log.WithError(err).Error("failed when getting cluster version")
+				os.Exit(1)
+			}
+			fmt.Println("")
+			fmt.Printf(" OpenShift: %s\n", clusterVersion.OpenShift)
+			fmt.Printf(" Kubernetes: %s\n", clusterVersion.Kubernetes)
 		},
 	}
 }

--- a/pkg/version/version_test.go
+++ b/pkg/version/version_test.go
@@ -1,0 +1,178 @@
+package version
+
+import (
+	"bytes"
+	"io"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/redhat-openshift-ecosystem/opct/pkg"
+	"github.com/vmware-tanzu/sonobuoy/pkg/buildinfo"
+)
+
+func TestVersionContext_String(t *testing.T) {
+	tests := []struct {
+		name    string
+		version VersionContext
+		want    string
+	}{
+		{
+			name: "development version with commit",
+			version: VersionContext{
+				Name:    "test-project",
+				Version: "0.0.0",
+				Commit:  "abc123def",
+			},
+			want: "OPCT CLI: 0.0.0+abc123def",
+		},
+		{
+			name: "release version without commit",
+			version: VersionContext{
+				Name:    "test-project",
+				Version: "1.2.3",
+				Commit:  "abc123def",
+			},
+			want: "OPCT CLI: 1.2.3",
+		},
+		{
+			name: "unknown version",
+			version: VersionContext{
+				Name:    "test-project",
+				Version: "unknown",
+				Commit:  "unknown",
+			},
+			want: "OPCT CLI: unknown",
+		},
+		{
+			name: "semver with v prefix",
+			version: VersionContext{
+				Name:    "test-project",
+				Version: "v0.6.1",
+				Commit:  "commit-hash",
+			},
+			want: "OPCT CLI: v0.6.1",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.version.String()
+			if got != tt.want {
+				t.Errorf("VersionContext.String() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestVersionContext_stringPluginsImage(t *testing.T) {
+	// Capture stdout
+	oldStdout := os.Stdout
+	r, w, _ := os.Pipe()
+	os.Stdout = w
+
+	vc := VersionContext{
+		Name:    "test-project",
+		Version: "1.0.0",
+		Commit:  "abc123",
+	}
+
+	vc.stringPluginsImage()
+
+	// Restore stdout
+	if err := w.Close(); err != nil {
+		t.Fatalf("Failed to close pipe writer: %v", err)
+	}
+	os.Stdout = oldStdout
+
+	// Read captured output
+	var buf bytes.Buffer
+	if _, err := io.Copy(&buf, r); err != nil {
+		t.Fatalf("Failed to copy pipe output: %v", err)
+	}
+	output := buf.String()
+
+	// Verify output contains expected plugin images
+	expectedStrings := []string{
+		"Images versions:",
+		pkg.SonobuoyImage,
+		buildinfo.Version,
+		pkg.PluginsImage,
+		pkg.CollectorImage,
+		pkg.MustGatherMonitoringImage,
+	}
+
+	for _, expected := range expectedStrings {
+		if !strings.Contains(output, expected) {
+			t.Errorf("stringPluginsImage() output missing %q\nGot: %s", expected, output)
+		}
+	}
+}
+
+func TestNewCmdVersion(t *testing.T) {
+	cmd := NewCmdVersion()
+
+	if cmd == nil {
+		t.Fatal("NewCmdVersion() returned nil")
+	}
+
+	if cmd.Use != "version" {
+		t.Errorf("NewCmdVersion().Use = %q, want %q", cmd.Use, "version")
+	}
+
+	if cmd.Short == "" {
+		t.Error("NewCmdVersion().Short is empty")
+	}
+
+	if cmd.Run == nil {
+		t.Error("NewCmdVersion().Run is nil")
+	}
+
+	// Verify the command has expected properties
+	expectedShort := "Print opct CLI version"
+	if cmd.Short != expectedShort {
+		t.Errorf("NewCmdVersion().Short = %q, want %q", cmd.Short, expectedShort)
+	}
+}
+
+func TestVersionGlobalVariable(t *testing.T) {
+	// Test that the global Version variable is properly initialized
+	if Version.Name == "" {
+		t.Error("Version.Name is empty")
+	}
+
+	if Version.Version == "" {
+		t.Error("Version.Version is empty")
+	}
+
+	if Version.Commit == "" {
+		t.Error("Version.Commit is empty")
+	}
+
+	// Verify default values
+	expectedName := "openshift-provider-cert"
+	if Version.Name != expectedName {
+		t.Errorf("Version.Name = %q, want %q", Version.Name, expectedName)
+	}
+}
+
+func TestVersionContext_Fields(t *testing.T) {
+	// Test struct field marshaling
+	vc := VersionContext{
+		Name:    "test-name",
+		Version: "test-version",
+		Commit:  "test-commit",
+	}
+
+	if vc.Name != "test-name" {
+		t.Errorf("VersionContext.Name = %q, want %q", vc.Name, "test-name")
+	}
+
+	if vc.Version != "test-version" {
+		t.Errorf("VersionContext.Version = %q, want %q", vc.Version, "test-version")
+	}
+
+	if vc.Commit != "test-commit" {
+		t.Errorf("VersionContext.Commit = %q, want %q", vc.Commit, "test-commit")
+	}
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

Enhance version command with more details about the environment, including plugins image versions and cluster version.

Enhancing version command to improve the stdout, specially when assets isn't collected:

~~~sh
$ make build-linux-amd64 
GOOS=linux GOARCH=amd64 go build -o /home/me/go/src/github.com/mtulio/opct/build/opct-linux-amd64 -ldflags '-s -w -X github.com/redhat-openshift-ecosystem/opct/pkg/version.commit=b1b2642f -X github.com/redhat-openshift-ecosystem/opct/pkg/version.version=0.0.0'
/home/me/go/src/github.com/mtulio/opct


$ ./build/opct-linux-amd64 version
OPCT CLI: 0.0.0+b1b2642f
Images versions:
 sonobuoy:v0.57.3 (library v0.57.3)
 plugin-openshift-tests:v0.6.1
 plugin-artifacts-collector:v0.6.1
 must-gather-monitoring:v0.6.1
Cluster version: unknown (KUBECONFIG is not set)

$ make build-linux-amd64 RELEASE_TAG=1.0.0
GOOS=linux GOARCH=amd64 go build -o /home/me/go/src/github.com/mtulio/opct/build/opct-linux-amd64 -ldflags '-s -w -X github.com/redhat-openshift-ecosystem/opct/pkg/version.commit=b1b2642f -X github.com/redhat-openshift-ecosystem/opct/pkg/version.version=1.0.0'
/home/me/go/src/github.com/mtulio/opct

$ ./build/opct-linux-amd64 version
OPCT CLI: 1.0.0
Images versions:
 sonobuoy:v0.57.3 (library v0.57.3)
 plugin-openshift-tests:v0.6.1
 plugin-artifacts-collector:v0.6.1
 must-gather-monitoring:v0.6.1
Cluster version: unknown (KUBECONFIG is not set)

$ export KUBECONFIG=$HOME/openshift/deploy/install-dir-v7/auth/kubeconfig 
$ ./build/opct-linux-amd64 version
OPCT CLI: 1.0.0
Images versions:
 sonobuoy:v0.57.3 (library v0.57.3)
 plugin-openshift-tests:v0.6.1
 plugin-artifacts-collector:v0.6.1
 must-gather-monitoring:v0.6.1
Cluster version: OpenShift: 4.22.0-ec.2
 Kubernetes: v1.34.2

~~~

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.
