### PR TITLE
OCPBUGS-77783: extract cluster pull-secret for release image auth

### DIFF
--- a/data/templates/plugins/openshift-kube-conformance.yaml
+++ b/data/templates/plugins/openshift-kube-conformance.yaml
@@ -71,11 +71,19 @@ podSpec:
             exit 0
           }
 
+          # Extract cluster pull-secret for registry auth (required for
+          # CI/nightly builds where the release image is on a private registry).
+          PULL_SECRET_ARG=""
+          if oc extract secret/pull-secret -n openshift-config --to=/tmp/ --confirm >/dev/null 2>&1; then
+            PULL_SECRET_ARG="-a /tmp/.dockerconfigjson"
+            echo "Using cluster pull-secret for release image auth"
+          fi
+
           # Get the hyperkube image from the release
           # Capture stdout (image ref) and stderr separately to avoid
           # warnings corrupting the image reference.
           RELEASE_STDERR=$(mktemp)
-          TESTS_IMAGE_K8S=$(oc adm release info --image-for=hyperkube 2>"$RELEASE_STDERR") || \
+          TESTS_IMAGE_K8S=$(oc adm release info ${PULL_SECRET_ARG-} --image-for=hyperkube 2>"$RELEASE_STDERR") || \
             init_error "Failed to get hyperkube image from release: $(cat "$RELEASE_STDERR")"
           if [ -z "$TESTS_IMAGE_K8S" ]; then
             init_error "Hyperkube image not found in release payload"


### PR DESCRIPTION
## Summary

Follow-up to #205. Extracts the cluster pull-secret before calling `oc adm release info` in the init container, enabling authentication to private registries used by CI/nightly builds.

## Problem

On CI/nightly builds, the release image is hosted on private registries (e.g. `registry.build09.ci.openshift.org`). The init container's `oc adm release info` call fails with `unauthorized: authentication required` because it has no registry credentials.

Stable releases (e.g. 4.20.19) work fine since the release image is on `quay.io` (public, no auth needed).

## Solution

Extract the cluster's global pull-secret from `openshift-config` namespace before calling `oc adm release info`, and pass it via `-a` flag. Uses `${PULL_SECRET_ARG-}` for safe expansion with `set -o nounset`.

```bash
PULL_SECRET_ARG=""
if oc extract secret/pull-secret -n openshift-config --to=/tmp/ --confirm >/dev/null 2>&1; then
    PULL_SECRET_ARG="-a /tmp/.dockerconfigjson"
fi
oc adm release info ${PULL_SECRET_ARG-} --image-for=hyperkube
```

## Related

- Bug: [OCPBUGS-77783](https://redhat.atlassian.net/browse/OCPBUGS-77783)
- Previous PR: #205 (merged)
- CI failure: https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/openshift_release/78839/periodic-ci-openshift-release-master-nightly-4.20-opct-external-aws-ccm/2049228468075368448