### PR TITLE
OPCT-426: fix: setSuiteName for kube conformance on OCP 5

### DIFF
--- a/pkg/run/run.go
+++ b/pkg/run/run.go
@@ -701,8 +701,6 @@ func (r *RunOptions) setSuiteName(cli *client.Client, configMapData map[string]s
 	// If 4.20+, set the suiteNameKubernetesConformance in the configMapData to "kubernetes/conformance/parallel",
 	// otherwise set it to "kubernetes/conformance".
 	// https://issues.redhat.com/browse/OCPBUGS-66219
-	suiteNameKubernetesConformance := "kubernetes/conformance"
-	suiteNameKubernetesConformanceParallel := "kubernetes/conformance/parallel"
 
 	// Get the cluster version
 	oc, err := coclient.NewForConfig(cli.RestConfig)
@@ -734,11 +732,18 @@ func (r *RunOptions) setSuiteName(cli *client.Client, configMapData map[string]s
 	}
 
 	// For OCP 4.20+, use k8s-tests-ext binary with parallel sub-suite
-	configMapData["suiteNameKubernetesConformance"] = suiteNameKubernetesConformance
-	if major == 4 && minor >= 20 {
-		configMapData["suiteNameKubernetesConformance"] = suiteNameKubernetesConformanceParallel
-	}
+	configMapData["suiteNameKubernetesConformance"] = resolveKubernetesSuiteName(major, minor)
 	log.Infof("Setting configMapData[suiteNameKubernetesConformance] to %s for OCP %d.%d", configMapData["suiteNameKubernetesConformance"], major, minor)
 
 	return nil
+}
+
+// resolveKubernetesSuiteName returns the Kubernetes conformance suite name
+// based on the OCP major.minor version. OCP 4.20+ (and any major > 4) use
+// the parallel sub-suite via k8s-tests-ext; older versions use the serial suite.
+func resolveKubernetesSuiteName(major, minor int) string {
+	if major > 4 || (major == 4 && minor >= 20) {
+		return "kubernetes/conformance/parallel"
+	}
+	return "kubernetes/conformance"
 }

--- a/pkg/run/run_test.go
+++ b/pkg/run/run_test.go
@@ -1,0 +1,66 @@
+package run
+
+import "testing"
+
+// TestResolveKubernetesSuiteName verifies the version-based suite selection for OCP 4.x and 5.x clusters.
+func TestResolveKubernetesSuiteName(t *testing.T) {
+	tests := []struct {
+		name     string
+		major    int
+		minor    int
+		expected string
+	}{
+		{
+			name:     "OCP 4.19 uses serial suite",
+			major:    4,
+			minor:    19,
+			expected: "kubernetes/conformance",
+		},
+		{
+			name:     "OCP 4.20 uses parallel suite",
+			major:    4,
+			minor:    20,
+			expected: "kubernetes/conformance/parallel",
+		},
+		{
+			name:     "OCP 4.21 uses parallel suite",
+			major:    4,
+			minor:    21,
+			expected: "kubernetes/conformance/parallel",
+		},
+		{
+			name:     "OCP 4.18 uses serial suite",
+			major:    4,
+			minor:    18,
+			expected: "kubernetes/conformance",
+		},
+		{
+			name:     "OCP 5.0 uses parallel suite",
+			major:    5,
+			minor:    0,
+			expected: "kubernetes/conformance/parallel",
+		},
+		{
+			name:     "OCP 5.1 uses parallel suite",
+			major:    5,
+			minor:    1,
+			expected: "kubernetes/conformance/parallel",
+		},
+		{
+			name:     "OCP 4.0 uses serial suite",
+			major:    4,
+			minor:    0,
+			expected: "kubernetes/conformance",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := resolveKubernetesSuiteName(tt.major, tt.minor)
+			if got != tt.expected {
+				t.Errorf("resolveKubernetesSuiteName(%d, %d) = %q, want %q",
+					tt.major, tt.minor, got, tt.expected)
+			}
+		})
+	}
+}


### PR DESCRIPTION

**What this PR does / why we need it**:

This change introduce the fix to set the correct suite name on OCP 5, where the name changed starting in 4.20.

https://redhat.atlassian.net/browse/OPCT-426

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.
