### PR TITLE
OPCT-410: add CI step to verify plugin images exist on quay.io

### DIFF
--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -84,11 +84,15 @@ jobs:
 
   verify-images:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     needs:
       - linters
       - reviewer
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
       - name: Extract and verify plugin images from types.go
         run: |
           set -euo pipefail
@@ -96,7 +100,13 @@ jobs:
           REPO=$(grep 'DefaultToolsRepository' pkg/types.go | grep -oP '"[^"]*"' | tr -d '"')
           echo "Registry: ${REPO}"
 
+          # Extract registry host and namespace from REPO (e.g., "quay.io/opct" -> host="quay.io", ns="opct")
+          REGISTRY_HOST="${REPO%%/*}"
+          NAMESPACE="${REPO#*/}"
+
           IMAGES=$(grep -E '(PluginsImage|CollectorImage|MustGatherMonitoringImage)\s*=' pkg/types.go | grep -oP '"[^"]*"' | tr -d '"')
+
+          ACCEPT="application/vnd.oci.image.index.v1+json, application/vnd.oci.image.manifest.v1+json, application/vnd.docker.distribution.manifest.v2+json, application/vnd.docker.distribution.manifest.list.v2+json"
 
           FAILED=0
           for IMG in $IMAGES; do
@@ -104,8 +114,8 @@ jobs:
             TAG="${IMG##*:}"
             FULL="${REPO}/${NAME}:${TAG}"
             HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" \
-              "https://quay.io/v2/opct/${NAME}/manifests/${TAG}" \
-              -H "Accept: application/vnd.oci.image.index.v1+json")
+              "https://${REGISTRY_HOST}/v2/${NAMESPACE}/${NAME}/manifests/${TAG}" \
+              -H "Accept: ${ACCEPT}")
             if [ "$HTTP_CODE" = "200" ]; then
               echo "✅ ${FULL}"
             else

--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -82,8 +82,51 @@ jobs:
           path: |
             build/opct-*
 
+  verify-images:
+    runs-on: ubuntu-latest
+    needs:
+      - linters
+      - reviewer
+    steps:
+      - uses: actions/checkout@v4
+      - name: Extract and verify plugin images from types.go
+        run: |
+          set -euo pipefail
+
+          REPO=$(grep 'DefaultToolsRepository' pkg/types.go | grep -oP '"[^"]*"' | tr -d '"')
+          echo "Registry: ${REPO}"
+
+          IMAGES=$(grep -E '(PluginsImage|CollectorImage|MustGatherMonitoringImage)\s*=' pkg/types.go | grep -oP '"[^"]*"' | tr -d '"')
+
+          FAILED=0
+          for IMG in $IMAGES; do
+            NAME="${IMG%%:*}"
+            TAG="${IMG##*:}"
+            FULL="${REPO}/${NAME}:${TAG}"
+            HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" \
+              "https://quay.io/v2/opct/${NAME}/manifests/${TAG}" \
+              -H "Accept: application/vnd.oci.image.index.v1+json")
+            if [ "$HTTP_CODE" = "200" ]; then
+              echo "✅ ${FULL}"
+            else
+              echo "❌ MISSING: ${FULL} (HTTP ${HTTP_CODE})"
+              FAILED=1
+            fi
+          done
+
+          if [ "$FAILED" = "1" ]; then
+            echo ""
+            echo "::error::One or more plugin images are missing on quay.io. Ensure provider-certification-plugins CI has completed successfully before bumping versions in pkg/types.go."
+            exit 1
+          fi
+
+          echo ""
+          echo "All plugin images verified successfully."
+
   e2e:
-    needs: build
+    needs:
+      - build
+      - verify-images
     uses: ./.github/workflows/e2e.yaml
 
   #

--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -97,7 +97,7 @@ jobs:
         run: |
           set -euo pipefail
 
-          REPO=$(grep 'DefaultToolsRepository' pkg/types.go | grep -oP '"[^"]*"' | tr -d '"')
+          REPO=$(grep -E 'DefaultToolsRepository\s*=' pkg/types.go | grep -oP '"[^"]*"' | tr -d '"')
           echo "Registry: ${REPO}"
 
           # Extract registry host and namespace from REPO (e.g., "quay.io/opct" -> host="quay.io", ns="opct")


### PR DESCRIPTION
## Summary
- Add `verify-images` job to `test-build-release` workflow that checks all plugin images referenced in `pkg/types.go` exist on quay.io
- Gate the `e2e` job on `verify-images` so the pipeline blocks if any image is missing
- Uses the public Quay v2 API (no auth needed) to verify manifests

## Why
When bumping versions in `pkg/types.go` for a release, if the `provider-certification-plugins` CI failed to build/push the plugin images, the OPCT binary would ship referencing non-existent images — broken at runtime. This was flagged by CodeRabbit on PR #215 but had no automated gate.

## Images verified
Extracted from `pkg/types.go`:
- `quay.io/opct/plugin-openshift-tests:TAG`
- `quay.io/opct/plugin-artifacts-collector:TAG`
- `quay.io/opct/must-gather-monitoring:TAG`

## Test plan
- [x] CI runs the new `verify-images` job and passes (current v0.6.5 images exist)
- [x] Local verification passes:
  ```
  ✅ quay.io/opct/plugin-openshift-tests:v0.6.5
  ✅ quay.io/opct/plugin-artifacts-collector:v0.6.5
  ✅ quay.io/opct/must-gather-monitoring:v0.6.5
  All plugin images verified successfully.
  ```
- [ ] Verify failure mode: temporarily change a version to non-existent tag → job should fail

🤖 Generated with [Claude Code](https://claude.com/claude-code)