### PR TITLE
OPCT-389: doc: update version matrix and conformance suite notes for OCP 4.20+

### DIFF
--- a/docs/guides/cluster-validation/index.md
+++ b/docs/guides/cluster-validation/index.md
@@ -190,7 +190,7 @@ The matrix below describes the OpenShift and OPCT versions supported:
 
     **Affected versions:**
 
-    - OPCT v0.6.0 and earlier do not support OCP 4.20+.
+    - OPCT v0.6.4 and earlier do not support OCP 4.20+.
     - OPCT v0.6.5+ is validated for OCP 4.19-4.22.
 
     **Fix details:**

--- a/docs/guides/cluster-validation/index.md
+++ b/docs/guides/cluster-validation/index.md
@@ -174,14 +174,33 @@ The matrix below describes the OpenShift and OPCT versions supported:
 
 | OPCT [version][releases] | OCP tested versions | OPCT Execution mode                |
 | --                       | --                  | --                                 |
-| v0.6.1+                  | 4.16-4.19           | regular, upgrade, disconnected     |
+| v0.6.5+                  | 4.19-4.22           | regular, upgrade, disconnected     |
+| v0.6.1-v0.6.4            | 4.16-4.19           | regular, upgrade, disconnected     |
 | v0.5.x-v0.6.0            | 4.14-4.19           | regular, upgrade, disconnected     |
 | v0.4.x                   | 4.10-4.13           | regular, upgrade, disconnected     |
 | v0.3.x                   | 4.9-4.12            | regular, upgrade                   |
 | v0.2.x                   | 4.9-4.11            | regular                            |
 | v0.1.x                   | 4.9-4.11            | regular                            |
 
-> Validations on OpenShift 4.20+ is currently blocked. See https://issues.redhat.com/browse/OCPBUGS-77783 for more information.
+!!! info "OCP 4.20+ conformance validation"
+    Validations on OCP 4.20+ were previously blocked by
+    [OCPBUGS-77783](https://issues.redhat.com/browse/OCPBUGS-77783) and
+    [OCPBUGS-84961](https://issues.redhat.com/browse/OCPBUGS-84961).
+    Both issues have been resolved and 4.20+ validations are now supported.
+
+    **Affected versions:**
+
+    - OPCT v0.6.0 and earlier do not support OCP 4.20+.
+    - OPCT v0.6.5+ is validated for OCP 4.19-4.22.
+
+    **Fix details:**
+
+    - The conformance suite fix is in `openshift-tests` ([openshift/origin](https://github.com/openshift/origin)),
+      not in OPCT. No OPCT plugin changes were required.
+    - OCP 4.20 was not affected by the conformance suite bug.
+    - OCP 4.21+ requires a nightly or z-stream release that includes the fix
+      ([origin PR #31353](https://github.com/openshift/origin/pull/31353) for 4.21,
+      [origin PR #31270](https://github.com/openshift/origin/pull/31270) for 4.22).
 
 It is highly recommended to use the latest OPCT version.
 


### PR DESCRIPTION
## Summary

Update the OPCT documentation to unblock VCSP validations on OCP 4.20+ and
address the acceptance criteria from [OPCT-389](https://redhat.atlassian.net/browse/OPCT-389).

### Changes
- Added `v0.6.5+` row supporting OCP 4.19-4.22 (CI workflows hardcode `quay.io/opct/opct:v0.6.5`)
- Narrowed previous `v0.6.1+` to `v0.6.1-v0.6.4` covering 4.16-4.19
- Removed the OCPBUGS-77783 blocking notice
- Added info block documenting:
  - Affected versions: OPCT v0.6.0 and earlier do not support 4.20+
  - Fix is in `openshift-tests` (openshift/origin), not in OPCT or plugins
  - OCP 4.20 was not affected by the conformance suite bug
  - OCP 4.21+ needs nightly or z-stream with origin PR #31353 (4.21) / #31270 (4.22)

### Why v0.6.5+ and not v0.6.1+ or v0.6.6+?
- All CI nightly workflows hardcode `OPCT_CLI_IMAGE: "quay.io/opct/opct:v0.6.5"`
- The conformance fix is in openshift/origin, not OPCT — no OPCT code change was needed
- v0.6.6 does not exist yet, and no changes after v0.6.5 are required for 4.20+ support

### CI note
The `e2e / e2e-cmd_adm-parse-metrics` test fails on this PR due to a missing
test artifact on CloudFront (HTTP 403). This is a pre-existing infrastructure
issue unrelated to this docs-only change.

Fixes: https://redhat.atlassian.net/browse/OPCT-389
Epic: https://redhat.atlassian.net/browse/OPCT-421

## Test plan
- [ ] Verify version matrix renders correctly on the published docs site
- [ ] Verify info block renders correctly
- [ ] Confirm no other docs reference the removed blocking notice

🤖 Generated with [Claude Code](https://claude.com/claude-code)